### PR TITLE
LoanPackage Updates

### DIFF
--- a/docs/mismo.md
+++ b/docs/mismo.md
@@ -45,6 +45,37 @@ is represented by the [`LoanState`](loan_state) proto.
 
 
 
+<a name="tech.figure.loan.v1beta1.MISMOLoanMetadata"></a>
+
+### MISMOLoanMetadata
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| uli | [string](#string) |  | Universal Loan Identifier (ULI) is a unique number made up of 23 to 45 characters that begins with the loan originator's Legal Entity Identifier (LEI). An originator's LEI can be found by searching the [GLEIF Website](https://search.gleif.org/#/search/). |
+| document | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) |  | Pointer to MISMO loan file in Object Store |
+| kv | [MISMOLoanMetadata.KvEntry](#tech.figure.loan.v1beta1.MISMOLoanMetadata.KvEntry) | repeated | Key-value map allowing originator to provide additional data |
+
+
+
+
+
+<a name="tech.figure.loan.v1beta1.MISMOLoanMetadata.KvEntry"></a>
+
+### MISMOLoanMetadata.KvEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [google.protobuf.Any](#google.protobuf.Any) |  |  |
+
+
+
+
+
 
 
 

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -37,6 +37,8 @@ Digital Asset Registry Technology (DART) ENote metadata
 | e_note | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) |  | Metadata of the authoritative copy of the ENote |
 | signed_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | Date the ENote was signed by the borrower |
 | vault_name | [string](#string) |  | Name of the eVault storing the Authoritative copy of the ENote |
+| modification | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Documents containing modifications to the ENote |
+| assumption | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Documents containing additional assumptions about the ENote |
 
 
 

--- a/docs/servicing.md
+++ b/docs/servicing.md
@@ -68,6 +68,23 @@ Loan state data (servicing data) at a point in time
 
 
 
+<a name="tech.figure.servicing.v1beta1.LoanStateMetadata"></a>
+
+### LoanStateMetadata
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Identifier unique to this document |
+| effective_time | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  |  |
+| uri | [string](#string) |  | URI Location where document is hosted/located |
+| checksum | [tech.figure.util.v1beta1.Checksum](util#tech.figure.util.v1beta1.Checksum) |  | Hash or checksum of document bytes |
+
+
+
+
+
 <a name="tech.figure.servicing.v1beta1.LoanStates"></a>
 
 ### LoanStates
@@ -114,9 +131,7 @@ Note: static data is possibly repeated elsewhere, but required here to make life
 | asset_type | [tech.figure.util.v1beta1.AssetType](util#tech.figure.util.v1beta1.AssetType) |  | Asset type (See docs/util.md) |
 | current_borrower_info | [tech.figure.util.v1beta1.Borrowers](util#tech.figure.util.v1beta1.Borrowers) |  | Borrower(s), co-signers, etc |
 | original_note_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Total unpaid principal balance when the note is signed |
-| uri | [string](#string) |  | Pointer to the object containing LoanStates message |
-| latest_checksum | [string](#string) |  | Checksum of the object containing LoanStates |
-| last_updated | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Last time the object checksum was updated |
+| loan_state | [LoanStateMetadata](#tech.figure.servicing.v1beta1.LoanStateMetadata) | repeated | List of pointers to the objects containing LoanState messages |
 
 
 

--- a/docs/servicing.md
+++ b/docs/servicing.md
@@ -46,6 +46,7 @@ Loan state data (servicing data) at a point in time
 | monthly_payment_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | The minimum monthly payment amount that borrower needs to repay on the loan |
 | principal_paid | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Sum of amount paid to principal |
 | past_due_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Amount past due |
+| deferred_principal | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Deferred Principal balance |
 | kv | [LoanState.KvEntry](#tech.figure.servicing.v1beta1.LoanState.KvEntry) | repeated | Additional loan state data for a user or tool-defined extension of state. Key is field name. Value is any proto Message. For scalar values, use <a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf">Protobuf Well-Known Types</a> |
 
 
@@ -75,11 +76,6 @@ List of loan states for a single loan
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| loan_id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Static Fields - repeated so that owner can
-
-Loan Identifier |
-| asset_type | [tech.figure.util.v1beta1.AssetType](util#tech.figure.util.v1beta1.AssetType) |  | Asset type (See docs/util.md) |
-| current_borrower_info | [tech.figure.util.v1beta1.Borrowers](util#tech.figure.util.v1beta1.Borrowers) |  | Borrower(s), co-signers, etc |
 | loan_state | [LoanState](#tech.figure.servicing.v1beta1.LoanState) | repeated | Individual loan states appended throughout life of loan |
 
 
@@ -96,6 +92,30 @@ Aggregation of loan state across a structure (group) of loans
 | ----- | ---- | ----- | ----------- |
 | marker_address | [string](#string) |  | Provenance Blockchain Address for the Marker representing this loan structure |
 | loan_states | [LoanState](#tech.figure.servicing.v1beta1.LoanState) | repeated | Loan state data for loans included in the structure |
+
+
+
+
+
+<a name="tech.figure.servicing.v1beta1.ServicingData"></a>
+
+### ServicingData
+Aggregation of loan state for a single loan
+
+A combination of static loan data that does not change throughout the life of the loan and a pointer to an object
+in the object store that contains a list of loan states
+
+Note: static data is possibly repeated elsewhere, but required here to make life easier for applications that require servicing data
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| loan_id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Loan Identifier |
+| asset_type | [tech.figure.util.v1beta1.AssetType](util#tech.figure.util.v1beta1.AssetType) |  | Asset type (See docs/util.md) |
+| current_borrower_info | [tech.figure.util.v1beta1.Borrowers](util#tech.figure.util.v1beta1.Borrowers) |  | Borrower(s), co-signers, etc |
+| uri | [string](#string) |  | Pointer to the object containing LoanStates message |
+| latest_checksum | [string](#string) |  | Checksum of the object containing LoanStates |
+| last_updated | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Last time the object checksum was updated |
 
 
 

--- a/docs/servicing.md
+++ b/docs/servicing.md
@@ -113,6 +113,7 @@ Note: static data is possibly repeated elsewhere, but required here to make life
 | loan_id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Loan Identifier |
 | asset_type | [tech.figure.util.v1beta1.AssetType](util#tech.figure.util.v1beta1.AssetType) |  | Asset type (See docs/util.md) |
 | current_borrower_info | [tech.figure.util.v1beta1.Borrowers](util#tech.figure.util.v1beta1.Borrowers) |  | Borrower(s), co-signers, etc |
+| original_note_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Total unpaid principal balance when the note is signed |
 | uri | [string](#string) |  | Pointer to the object containing LoanStates message |
 | latest_checksum | [string](#string) |  | Checksum of the object containing LoanStates |
 | last_updated | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Last time the object checksum was updated |

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -19,6 +19,22 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | iteration | [ValidationIteration](#tech.figure.validation.v1beta1.ValidationIteration) | repeated |  |
+| kv | [LoanValidation.KvEntry](#tech.figure.validation.v1beta1.LoanValidation.KvEntry) | repeated |  |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta1.LoanValidation.KvEntry"></a>
+
+### LoanValidation.KvEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [google.protobuf.Any](#google.protobuf.Any) |  |  |
 
 
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,0 +1,221 @@
+# Loan Validation
+<a name="top"></a>
+
+
+
+<a name="tech/figure/validation/v1beta1/validation.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## tech/figure/validation/v1beta1/validation.proto
+
+
+
+<a name="tech.figure.validation.v1beta1.LoanValidation"></a>
+
+### LoanValidation
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| iteration | [ValidationIteration](#tech.figure.validation.v1beta1.ValidationIteration) | repeated |  |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta1.ValidationItem"></a>
+
+### ValidationItem
+Individual rules that were executed, including the actual expression that was run
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| code | [string](#string) |  | Identifier for the rule |
+| label | [string](#string) |  | Short description of the rule |
+| description | [string](#string) |  | Long description of the rule |
+| expression | [string](#string) |  | Actual value, comparison operator, and expected value written as a formula or description of a comparison |
+| validation_outcome | [ValidationOutcome](#tech.figure.validation.v1beta1.ValidationOutcome) |  | Result of applying the rule, see enum |
+| kv | [ValidationItem.KvEntry](#tech.figure.validation.v1beta1.ValidationItem.KvEntry) | repeated | Additional information related to the rule |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta1.ValidationItem.KvEntry"></a>
+
+### ValidationItem.KvEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [google.protobuf.Any](#google.protobuf.Any) |  |  |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta1.ValidationIteration"></a>
+
+### ValidationIteration
+List of validation request/response objects
+
+Each loan can go through several rounds of validation
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| request | [ValidationRequest](#tech.figure.validation.v1beta1.ValidationRequest) |  |  |
+| results | [ValidationResults](#tech.figure.validation.v1beta1.ValidationResults) |  |  |
+| kv | [ValidationIteration.KvEntry](#tech.figure.validation.v1beta1.ValidationIteration.KvEntry) | repeated |  |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta1.ValidationIteration.KvEntry"></a>
+
+### ValidationIteration.KvEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [google.protobuf.Any](#google.protobuf.Any) |  |  |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta1.ValidationRequest"></a>
+
+### ValidationRequest
+Validation request including a pointer to the snapshot of data requiring validation
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| request_id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Unique ID for the request |
+| effective_time | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Time the validation was requested |
+| snapshot_uri | [string](#string) |  | Pointer to the snapshot |
+| rule_set_id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | ID of rule set that needs to be executed |
+| description | [string](#string) |  | Description of the rule set |
+| validator_name | [string](#string) |  | Party that will run the validation |
+| requester_name | [string](#string) |  | Party invoking the request for validation |
+| kv | [ValidationRequest.KvEntry](#tech.figure.validation.v1beta1.ValidationRequest.KvEntry) | repeated | Additional fields from the requester |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta1.ValidationRequest.KvEntry"></a>
+
+### ValidationRequest.KvEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [google.protobuf.Any](#google.protobuf.Any) |  |  |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta1.ValidationResponse"></a>
+
+### ValidationResponse
+Input to the validation results p8e contract
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| request_id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Unique ID for the request - should match existing request |
+| results | [ValidationResults](#tech.figure.validation.v1beta1.ValidationResults) |  | Validation results associated with the request |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta1.ValidationResults"></a>
+
+### ValidationResults
+Validation results that get stored alongside the validation request when validation is complete
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| result_set_uuid | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | unique ID for the result set |
+| result_set_effective_time | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | the date the validation was finalized |
+| result_set_provider | [string](#string) |  | name of the validator |
+| validation_exception_count | [int32](#int32) |  | Total count of exceptions |
+| validation_warning_count | [int32](#int32) |  | Total count of warnings |
+| validation_items | [ValidationItem](#tech.figure.validation.v1beta1.ValidationItem) | repeated | Individual rules that were executed |
+| policy_documents | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Related Documents like TPR Indemnification Policy, deligence scope |
+| rating_agency_grading | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) |  | Document containing credit rating agency grades |
+| kv | [ValidationResults.KvEntry](#tech.figure.validation.v1beta1.ValidationResults.KvEntry) | repeated | Additional fields from the validator |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta1.ValidationResults.KvEntry"></a>
+
+### ValidationResults.KvEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [google.protobuf.Any](#google.protobuf.Any) |  |  |
+
+
+
+
+
+
+
+<a name="tech.figure.validation.v1beta1.ValidationOutcome"></a>
+
+### ValidationOutcome
+Possible outcomes when applying a validation rule
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| UNKNOWN_TYPE | 0 |  |
+| EXCEPTION | 1 |  |
+| WARNING | 2 |  |
+| VALID | 3 |  |
+
+
+
+
+
+
+
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ | Java | Python | Go | C# | PHP | Ruby |
+| ----------- | ----- | --- | ---- | ------ | -- | -- | --- | ---- |
+| <a name="double" /> double |  | double | double | float | float64 | double | float | Float |
+| <a name="float" /> float |  | float | float | float | float32 | float | float | Float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum or Fixnum (as required) |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="bool" /> bool |  | bool | boolean | boolean | bool | bool | boolean | TrueClass/FalseClass |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode | string | string | string | String (UTF-8) |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str | []byte | ByteString | string | String (ASCII-8BIT) |

--- a/make-docs.sh
+++ b/make-docs.sh
@@ -32,6 +32,7 @@ cp -r build/extracted-include-protos/main/validate ${TMP_DIR}
 gen_doc "tech/figure/asset/v1beta1/asset.proto" "asset.md" "Asset (NFT)"
 gen_doc "tech/figure/loan/v1beta1/loan.proto" "loan.md" "Loan"
 gen_doc "tech/figure/loan/v1beta1/mismo_loan.proto" "mismo.md" "MISMO Loan"
+gen_doc "tech/figure/validation/v1beta1/validation.proto" "validation.md" "Loan Validation"
 gen_doc "io/dartinc/registry/v1beta1/registry.proto" "registry.md" "Digital Asset Registry Technology"
 
 pushd ${TMP_DIR}

--- a/src/main/proto/io/dartinc/registry/v1beta1/registry.proto
+++ b/src/main/proto/io/dartinc/registry/v1beta1/registry.proto
@@ -12,15 +12,15 @@ import "validate/validate.proto";
 Digital Asset Registry Technology (DART) ENote metadata
  */
 message ENote {
-  Controller                                controller      = 1 [(validate.rules).message.required = true]; // Identity of the ENote controller
-  tech.figure.util.v1beta1.DocumentMetadata e_note          = 2 [(validate.rules).message.required = true]; // Metadata of the authoritative copy of the ENote
-  tech.figure.util.v1beta1.Date             signed_date     = 3 [(validate.rules).message.required = true]; // Date the ENote was signed by the borrower
-  string                                    vault_name      = 4 [(validate.rules).string.min_len = 1];      // Name of the eVault storing the Authoritative copy of the ENote
-//  bool                                      modification    = 10;                                           // Modifications to the ENote
-//  bool                                      assumption      = 20;                                           // Assumption about the ENote
+  Controller                                            controller      = 1 [(validate.rules).message.required = true]; // Identity of the ENote controller
+  tech.figure.util.v1beta1.DocumentMetadata             e_note          = 2 [(validate.rules).message.required = true]; // Metadata of the authoritative copy of the ENote
+  tech.figure.util.v1beta1.Date                         signed_date     = 3 [(validate.rules).message.required = true]; // Date the ENote was signed by the borrower
+  string                                                vault_name      = 4 [(validate.rules).string.min_len = 1];      // Name of the eVault storing the Authoritative copy of the ENote
+  repeated tech.figure.util.v1beta1.DocumentMetadata    modification    = 10;                                           // Documents containing modifications to the ENote
+  repeated tech.figure.util.v1beta1.DocumentMetadata    assumption      = 20;                                           // Documents containing additional assumptions about the ENote
 }
 
 message Controller {
-  tech.figure.util.v1beta1.UUID             controller_uuid = 1 [(validate.rules).message.required = true]; // ENote controller ID
-  string                                    controller_name = 2 [(validate.rules).string.min_len = 1];      // ENote controller name
+  tech.figure.util.v1beta1.UUID                         controller_uuid = 1 [(validate.rules).message.required = true]; // ENote controller ID
+  string                                                controller_name = 2 [(validate.rules).string.min_len = 1];      // ENote controller name
 }

--- a/src/main/proto/tech/figure/loan/v1beta1/mismo_loan.proto
+++ b/src/main/proto/tech/figure/loan/v1beta1/mismo_loan.proto
@@ -6,6 +6,7 @@ option java_multiple_files = true;
 
 import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
+import "tech/figure/util/v1beta1/document.proto";
 import "validate/validate.proto";
 
 /*
@@ -17,13 +18,22 @@ is represented by the [`LoanState`](loan_state) proto.
 */
 message MISMOLoan {
   /*
-  Universal Loan Identifier (ULI) is a unique number made up of 23 to 45 characters that begins with the loan
-  originator's Legal Entity Identifier (LEI).
-  An originator's LEI can be found by searching the [GLEIF Website](https://search.gleif.org/#/search/).
-   */
+    Universal Loan Identifier (ULI) is a unique number made up of 23 to 45 characters that begins with the loan
+    originator's Legal Entity Identifier (LEI).
+    An originator's LEI can be found by searching the [GLEIF Website](https://search.gleif.org/#/search/).
+  */
   string                            uli   = 1 [(validate.rules).string.min_len = 23, (validate.rules).string.max_len = 45];
-  // Byte array of the MISMO XML file
-  google.protobuf.BytesValue        data  = 2 [(validate.rules).message.required = true];
-  // Key-value map allowing originator to provide additional data
-  map<string, google.protobuf.Any>  kv    = 99;
+  google.protobuf.BytesValue        data  = 2 [(validate.rules).message.required = true]; // Byte array of the MISMO XML file
+  map<string, google.protobuf.Any>  kv    = 99;// Key-value map allowing originator to provide additional data
+}
+
+message MISMOLoanMetadata {
+  /*
+    Universal Loan Identifier (ULI) is a unique number made up of 23 to 45 characters that begins with the loan
+    originator's Legal Entity Identifier (LEI).
+    An originator's LEI can be found by searching the [GLEIF Website](https://search.gleif.org/#/search/).
+  */
+  string                                    uli       = 1 [(validate.rules).string.min_len = 23, (validate.rules).string.max_len = 45];
+  tech.figure.util.v1beta1.DocumentMetadata document  = 2; // Pointer to MISMO loan file in Object Store
+  map<string, google.protobuf.Any>          kv        = 99; // Key-value map allowing originator to provide additional data
 }

--- a/src/main/proto/tech/figure/servicing/v1beta1/loan_state.proto
+++ b/src/main/proto/tech/figure/servicing/v1beta1/loan_state.proto
@@ -17,13 +17,26 @@ message LoanStructureState {
 }
 
 /*
-List of loan states for a single loan
+Aggregation of loan state for a single loan
+
+A combination of static loan data that does not change throughout the life of the loan and a pointer to an object
+in the object store that contains a list of loan states
+
+Note: static data is possibly repeated elsewhere, but required here to make life easier for applications that require servicing data
  */
-message LoanStates {
-  // Static Fields - repeated so that owner can
+message ServicingData {
   tech.figure.util.v1beta1.UUID      loan_id                = 1 [(validate.rules).message.required = true]; // Loan Identifier
   tech.figure.util.v1beta1.AssetType asset_type             = 2 [(validate.rules).message.required = true]; // Asset type (See docs/util.md)
   tech.figure.util.v1beta1.Borrowers current_borrower_info  = 3;                                            // Borrower(s), co-signers, etc
+	string                             uri                    = 10;                                           // Pointer to the object containing LoanStates message
+  string                             latest_checksum        = 11;                                           // Checksum of the object containing LoanStates
+  google.protobuf.Timestamp          last_updated           = 12;                                           // Last time the object checksum was updated
+}
+
+/*
+List of loan states for a single loan
+ */
+message LoanStates {
   repeated LoanState                 loan_state             = 10;                                           // Individual loan states appended throughout life of loan
 }
 

--- a/src/main/proto/tech/figure/servicing/v1beta1/loan_state.proto
+++ b/src/main/proto/tech/figure/servicing/v1beta1/loan_state.proto
@@ -25,31 +25,36 @@ in the object store that contains a list of loan states
 Note: static data is possibly repeated elsewhere, but required here to make life easier for applications that require servicing data
  */
 message ServicingData {
-  tech.figure.util.v1beta1.UUID      loan_id                = 1 [(validate.rules).message.required = true]; // Loan Identifier
-  tech.figure.util.v1beta1.AssetType asset_type             = 2 [(validate.rules).message.required = true]; // Asset type (See docs/util.md)
-  tech.figure.util.v1beta1.Borrowers current_borrower_info  = 3;                                            // Borrower(s), co-signers, etc
-  tech.figure.util.v1beta1.Money     original_note_amount   = 4 [(validate.rules).message.required = true]; // Total unpaid principal balance when the note is signed
-	string                             uri                    = 10;                                           // Pointer to the object containing LoanStates message
-  string                             latest_checksum        = 11;                                           // Checksum of the object containing LoanStates
-  google.protobuf.Timestamp          last_updated           = 12;                                           // Last time the object checksum was updated
+  tech.figure.util.v1beta1.UUID       loan_id                = 1 [(validate.rules).message.required = true]; // Loan Identifier
+  tech.figure.util.v1beta1.AssetType  asset_type             = 2 [(validate.rules).message.required = true]; // Asset type (See docs/util.md)
+  tech.figure.util.v1beta1.Borrowers  current_borrower_info  = 3;                                            // Borrower(s), co-signers, etc
+  tech.figure.util.v1beta1.Money      original_note_amount   = 4 [(validate.rules).message.required = true]; // Total unpaid principal balance when the note is signed
+	repeated LoanStateMetadata          loan_state             = 10;                                           // List of pointers to the objects containing LoanState messages
+}
+
+message LoanStateMetadata {
+  tech.figure.util.v1beta1.UUID       id              = 1 [(validate.rules).message.required = true]; // Identifier unique to this document
+  google.protobuf.Timestamp           effective_time  = 2;
+  string                              uri             = 3;                                            // URI Location where document is hosted/located
+  tech.figure.util.v1beta1.Checksum   checksum        = 4;                                            // Hash or checksum of document bytes
 }
 
 /*
 List of loan states for a single loan
  */
 message LoanStates {
-  repeated LoanState                 loan_state             = 10;                                           // Individual loan states appended throughout life of loan
+  repeated LoanState                  loan_state             = 10;                                           // Individual loan states appended throughout life of loan
 }
 
 /*
 Loan state data (servicing data) at a point in time
  */
 message LoanState {
-  google.protobuf.Timestamp        effective_time           = 1 [(validate.rules).timestamp.required = true, (validate.rules).timestamp.lt_now = true]; // Timestamp when this state was produced
-  string                           servicer_name            = 2 [(validate.rules).string.min_len = 1];                                                  // Name of servicer for loan
-  tech.figure.util.v1beta1.Money   total_unpaid_prin_bal    = 3 [(validate.rules).message.required = true];                                             // Total unpaid principal balance
-  tech.figure.util.v1beta1.Money   accrued_interest         = 4 [(validate.rules).message.required = true];                                             // Total interest accrued to-date
-  tech.figure.util.v1beta1.Money   daily_int_amount         = 5 [(validate.rules).message.required = true];                                             // Accrued interest amount per day
+  google.protobuf.Timestamp           effective_time           = 1 [(validate.rules).timestamp.required = true, (validate.rules).timestamp.lt_now = true]; // Timestamp when this state was produced
+  string                              servicer_name            = 2 [(validate.rules).string.min_len = 1];                                                  // Name of servicer for loan
+  tech.figure.util.v1beta1.Money      total_unpaid_prin_bal    = 3 [(validate.rules).message.required = true];                                             // Total unpaid principal balance
+  tech.figure.util.v1beta1.Money      accrued_interest         = 4 [(validate.rules).message.required = true];                                             // Total interest accrued to-date
+  tech.figure.util.v1beta1.Money      daily_int_amount         = 5 [(validate.rules).message.required = true];                                             // Accrued interest amount per day
   /*
     Loan status, such as:
     IN REPAY
@@ -63,34 +68,34 @@ message LoanState {
     FORBEARANCE
     TRANSFERRED
   */
-  tech.figure.util.v1beta1.Status  loan_status              = 6;
-  tech.figure.util.v1beta1.Money   current_p_and_i          = 7; // Currently monthly loan payment amount including principal and interest
-  tech.figure.util.v1beta1.Rate    current_interest_rate    = 8; // The current interest rate used to calculate the principal and interest payment
-  tech.figure.util.v1beta1.Date    int_accrual_start_date   = 9; // The date on which interest accrual began
-  tech.figure.util.v1beta1.Date    int_paid_through_date    = 10; // The date through which interest is paid with the current payment. The effective date from which interest will be calculated for the application of the next payment.
-  tech.figure.util.v1beta1.Date    maturity_date            = 11; // The date when a loan reaches maturity
-  tech.figure.util.v1beta1.Date    next_due_date            = 12; // Date of next due payment for loan
-  int32                            days_delinquent          = 13; // Number of days delinquent
-  int32                            remaining_term_months    = 14; // Remaining loan term in months
-  tech.figure.util.v1beta1.Rate    servicing_fee_rate       = 15; // The fee paid to the servicer, stated as a percentage of the outstanding loan balance
-  tech.figure.util.v1beta1.Rate    apr                      = 16; // Annualized Percentage Rate of the loan
-  bool                             autopay_flag             = 17; // If true, payments are automatically deducted from borrower's financial account
-  tech.figure.util.v1beta1.Money   deferred_int_balance     = 18; // Accumulated Interest balance since forbearance_begin_date
-  tech.figure.util.v1beta1.Date    delinquent_date          = 19; // If delinquent, date first payment was missed that made the loan currently delinquent
-  uint32                           days_forbearance         = 20; // Days elapsed since entering Forbearance
-  tech.figure.util.v1beta1.Date    forbearance_begin_date   = 21; // Date forbearance period begins
-  tech.figure.util.v1beta1.Date    forbearance_end_date     = 22; // Date forbearance period ends
-  tech.figure.util.v1beta1.Money   interest_paid            = 23; // Total interest paid to-date
-  tech.figure.util.v1beta1.Rate    interest_rate_cap        = 24; // Interest rate cap
-  tech.figure.util.v1beta1.Date    last_payment_date        = 25; // Last payment received date
-  tech.figure.util.v1beta1.Money   monthly_payment_amount   = 26; // The minimum monthly payment amount that borrower needs to repay on the loan
-  tech.figure.util.v1beta1.Money   principal_paid           = 27; // Sum of amount paid to principal
-  tech.figure.util.v1beta1.Money   past_due_amount          = 28; // Amount past due
-  tech.figure.util.v1beta1.Money   deferred_principal       = 29; // Deferred Principal balance
+  tech.figure.util.v1beta1.Status     loan_status              = 6;
+  tech.figure.util.v1beta1.Money      current_p_and_i          = 7; // Currently monthly loan payment amount including principal and interest
+  tech.figure.util.v1beta1.Rate       current_interest_rate    = 8; // The current interest rate used to calculate the principal and interest payment
+  tech.figure.util.v1beta1.Date       int_accrual_start_date   = 9; // The date on which interest accrual began
+  tech.figure.util.v1beta1.Date       int_paid_through_date    = 10; // The date through which interest is paid with the current payment. The effective date from which interest will be calculated for the application of the next payment.
+  tech.figure.util.v1beta1.Date       maturity_date            = 11; // The date when a loan reaches maturity
+  tech.figure.util.v1beta1.Date       next_due_date            = 12; // Date of next due payment for loan
+  int32                               days_delinquent          = 13; // Number of days delinquent
+  int32                               remaining_term_months    = 14; // Remaining loan term in months
+  tech.figure.util.v1beta1.Rate       servicing_fee_rate       = 15; // The fee paid to the servicer, stated as a percentage of the outstanding loan balance
+  tech.figure.util.v1beta1.Rate       apr                      = 16; // Annualized Percentage Rate of the loan
+  bool                                autopay_flag             = 17; // If true, payments are automatically deducted from borrower's financial account
+  tech.figure.util.v1beta1.Money      deferred_int_balance     = 18; // Accumulated Interest balance since forbearance_begin_date
+  tech.figure.util.v1beta1.Date       delinquent_date          = 19; // If delinquent, date first payment was missed that made the loan currently delinquent
+  uint32                              days_forbearance         = 20; // Days elapsed since entering Forbearance
+  tech.figure.util.v1beta1.Date       forbearance_begin_date   = 21; // Date forbearance period begins
+  tech.figure.util.v1beta1.Date       forbearance_end_date     = 22; // Date forbearance period ends
+  tech.figure.util.v1beta1.Money      interest_paid            = 23; // Total interest paid to-date
+  tech.figure.util.v1beta1.Rate       interest_rate_cap        = 24; // Interest rate cap
+  tech.figure.util.v1beta1.Date       last_payment_date        = 25; // Last payment received date
+  tech.figure.util.v1beta1.Money      monthly_payment_amount   = 26; // The minimum monthly payment amount that borrower needs to repay on the loan
+  tech.figure.util.v1beta1.Money      principal_paid           = 27; // Sum of amount paid to principal
+  tech.figure.util.v1beta1.Money      past_due_amount          = 28; // Amount past due
+  tech.figure.util.v1beta1.Money      deferred_principal       = 29; // Deferred Principal balance
 
   /*
     Additional loan state data for a user or tool-defined extension of state. Key is field name. Value is any proto Message.
     For scalar values, use <a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf">Protobuf Well-Known Types</a>
   */
-  map<string, google.protobuf.Any> kv                       = 99;
+  map<string, google.protobuf.Any>    kv                       = 99;
 }

--- a/src/main/proto/tech/figure/servicing/v1beta1/loan_state.proto
+++ b/src/main/proto/tech/figure/servicing/v1beta1/loan_state.proto
@@ -28,6 +28,7 @@ message ServicingData {
   tech.figure.util.v1beta1.UUID      loan_id                = 1 [(validate.rules).message.required = true]; // Loan Identifier
   tech.figure.util.v1beta1.AssetType asset_type             = 2 [(validate.rules).message.required = true]; // Asset type (See docs/util.md)
   tech.figure.util.v1beta1.Borrowers current_borrower_info  = 3;                                            // Borrower(s), co-signers, etc
+  tech.figure.util.v1beta1.Money     original_note_amount   = 4 [(validate.rules).message.required = true]; // Total unpaid principal balance when the note is signed
 	string                             uri                    = 10;                                           // Pointer to the object containing LoanStates message
   string                             latest_checksum        = 11;                                           // Checksum of the object containing LoanStates
   google.protobuf.Timestamp          last_updated           = 12;                                           // Last time the object checksum was updated

--- a/src/main/proto/tech/figure/validation/v1beta1/validation.proto
+++ b/src/main/proto/tech/figure/validation/v1beta1/validation.proto
@@ -44,8 +44,8 @@ message ValidationRequest {
 Input to the validation results p8e contract
  */
 message ValidationResponse {
-		tech.figure.util.v1beta1.UUID     request_id          = 1; // Unique ID for the request - should match existing request
-		ValidationResults                 results             = 2; // Validation results associated with the request
+  tech.figure.util.v1beta1.UUID     request_id          = 1; // Unique ID for the request - should match existing request
+  ValidationResults                 results             = 2; // Validation results associated with the request
 }
 
 /*

--- a/src/main/proto/tech/figure/validation/v1beta1/validation.proto
+++ b/src/main/proto/tech/figure/validation/v1beta1/validation.proto
@@ -12,6 +12,7 @@ import "validate/validate.proto";
 
 message LoanValidation {
   repeated ValidationIteration      iteration    = 1;
+  map<string, google.protobuf.Any>  kv           = 99;
 }
 
 /*

--- a/src/main/proto/tech/figure/validation/v1beta1/validation.proto
+++ b/src/main/proto/tech/figure/validation/v1beta1/validation.proto
@@ -10,7 +10,7 @@ import "tech/figure/util/v1beta1/document.proto";
 import "tech/figure/util/v1beta1/types.proto";
 import "validate/validate.proto";
 
-message Validation {
+message LoanValidation {
   repeated ValidationIteration      iteration    = 1;
 }
 
@@ -31,18 +31,24 @@ Validation request including a pointer to the snapshot of data requiring validat
 message ValidationRequest {
   tech.figure.util.v1beta1.UUID       request_id          = 1 [(validate.rules).message.required = true];   // Unique ID for the request
   google.protobuf.Timestamp           effective_time      = 2 [(validate.rules).timestamp.required = true]; // Time the validation was requested
-  string                              object_store        = 3 [(validate.rules).string.min_len = 1];        // Name of the Object Store where the snapshot lives
-  string                              snapshot_uri        = 4 [(validate.rules).string.min_len = 1];        // Pointer to the snapshot
-  tech.figure.util.v1beta1.UUID       rule_set_id         = 5;                                              // ID of rule set that needs to be executed
-  string                              description         = 6;                                              // Description of the rule set
-  string                              validator_name      = 7 [(validate.rules).string.min_len = 1];        // Party that will run the validation
-  string                              requester_name      = 8 [(validate.rules).string.min_len = 1];        // Party invoking the request for validation
-  string                              status              = 9;                                              // PENDING, IN_PROCESS, COMPLETED
+  string                              snapshot_uri        = 3 [(validate.rules).string.min_len = 1];        // Pointer to the snapshot
+  tech.figure.util.v1beta1.UUID       rule_set_id         = 4;                                              // ID of rule set that needs to be executed
+  string                              description         = 5;                                              // Description of the rule set
+  string                              validator_name      = 6 [(validate.rules).string.min_len = 1];        // Party that will run the validation
+  string                              requester_name      = 7 [(validate.rules).string.min_len = 1];        // Party invoking the request for validation
   map<string, google.protobuf.Any>    kv                  = 99;                                             // Additional fields from the requester
 }
 
 /*
-Validation results that get posted when validation is complete
+Input to the validation results p8e contract
+ */
+message ValidationResponse {
+		tech.figure.util.v1beta1.UUID     request_id          = 1; // Unique ID for the request - should match existing request
+		ValidationResults                 results             = 2; // Validation results associated with the request
+}
+
+/*
+Validation results that get stored alongside the validation request when validation is complete
  */
 message ValidationResults {
   tech.figure.util.v1beta1.UUID                       result_set_uuid             = 1;  // unique ID for the result set
@@ -62,7 +68,7 @@ Individual rules that were executed, including the actual expression that was ru
 message ValidationItem {
   string                                      code                = 1;  // Identifier for the rule
   string                                      label               = 2;  // Short description of the rule
-  string                                      descr               = 3;  // Long description of the rule
+  string                                      description         = 3;  // Long description of the rule
   string                                      expression          = 4;  // Actual value, comparison operator, and expected value written as a formula or description of a comparison
   ValidationOutcome                           validation_outcome  = 5;  // Result of applying the rule, see enum
   map<string, google.protobuf.Any>            kv                  = 99; // Additional information related to the rule


### PR DESCRIPTION
Servicing:
- Rather than storing long list of LoanStates in the Loan Scope, store pointer to LoanStates that live in an object in the Object Store using the new ServicingData message
Validation:
- Minor naming change to specify that this is meant for loan validation
- Add ValidationResponse message that acts as the input to validation response contracts that implement the rest of the validation protos
Registry/Enote:
- Uncomment modifications and assumptions and treat them like other documents stored in the Object Store