### PR TITLE
Define LoanStateMetadata list wrapper for use in p8e contracts

### DIFF
--- a/docs/servicing.md
+++ b/docs/servicing.md
@@ -86,6 +86,20 @@ Loan state data (servicing data) at a point in time
 
 
 
+<a name="tech.figure.servicing.v1beta1.LoanStateSubmission"></a>
+
+### LoanStateSubmission
+A submission of loan state metadata for a single loan
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| loan_state | [LoanStateMetadata](#tech.figure.servicing.v1beta1.LoanStateMetadata) | repeated | Loan state metadata for the loan |
+
+
+
+
+
 <a name="tech.figure.servicing.v1beta1.LoanStructureState"></a>
 
 ### LoanStructureState

--- a/src/main/proto/tech/figure/servicing/v1beta1/loan_state.proto
+++ b/src/main/proto/tech/figure/servicing/v1beta1/loan_state.proto
@@ -17,6 +17,13 @@ message LoanStructureState {
   repeated LoanState loan_states    = 2; // Loan state data for loans included in the structure
 }
 
+/**
+A submission of loan state metadata for a single loan
+ */
+message LoanStateSubmission {
+  repeated LoanStateMetadata loan_state = 1; // Loan state metadata for the loan
+}
+
 /*
 Aggregation of loan state for a single loan
 


### PR DESCRIPTION
## Context
We are unable to use types which aren't direct subclasses of `com.google.protobuf.Message`, [like `Collection<out Message>`](https://github.com/provenance-io/loan-package-contracts/blob/6b8bade2b0f69f64bc8faf8af31d46d822bbd3a6/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContract.kt#L24), in `p8e-scope-sdk` contracts due to [limitations in the current SDK for adding records](https://github.com/provenance-io/p8e-scope-sdk/blob/1864a83e923a8ae0a665af893fae166941ab86ca/sdk/src/main/kotlin/io/provenance/scope/sdk/SessionBuilder.kt#L204). To keep input protobuf definitions for https://github.com/provenance-io/loan-package-contracts specific and centralized in this project, let's define a list wrapping protobuf for submitting to said contract.
## Changes
- Add protobuf definition which solely defines a list of `LoanStateMetadata`
- Update docs accordingly