### PR TITLE
Add some missing DART fields

### DIFF
--- a/docs/asset.md
+++ b/docs/asset.md
@@ -18,12 +18,51 @@ represented by one or more [Google Protocol Buffers](https://developers.google.c
 
 For specific asset types, use a domain-specific protobuf, such as a [`Loan`](loan#loan-1), in the `kv` map.
 
-INSERT_EXAMPLE
+
+Example:
+```json
+{
+  "id": "c6978d46-3c3e-4175-a0d2-8f8ce47e8bb6",
+  "type": "LOAN",
+  "description": "PERSONAL_LOAN LOAN-1234",
+  "kv": {
+    "loan": {
+      "id": "c6978d46-3c3e-4175-a0d2-8f8ce47e8bb6",
+      "originatorName": "Example Loan Company",
+      "originatorLoanId": "LOAN-1234",
+      "loanType": "PERSONAL_LOAN",
+      "terms": {
+        "principalAmount": {
+          "amount": 10000.00,
+          "currency": "USD"
+        },
+        "totalAmount": {
+          "amount": 10200.00,
+          "currency": "USD"
+        },
+        "termInMonths": 12,
+        "interestRate": {
+          "value": 0.065
+        }
+      },
+      "funding": {
+        "started": false,
+        "completed": false
+      },
+      "assetType": {
+        "supertype": "PERSONAL_LOAN"
+      },
+      "uli": "LEI456123456123456123456123",
+      "originatorUuid": "00000000-0000-0000-0000-000000000000"
+    }
+  }
+} 
+```
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [tech.figure.util.v1beta1.UUID](#tech.figure.util.v1beta1.UUID) |  | Required UUID identifier for this asset |
+| id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Required UUID identifier for this asset |
 | type | [string](#string) |  | Optional user-defined type (e.g. LOAN, ART, PROPERTY TITLE, FUND, SHARE CLASS) |
 | description | [string](#string) |  | Optional user-defined description, title, name, etc. for display |
 | kv | [Asset.KvEntry](#tech.figure.asset.v1beta1.Asset.KvEntry) | repeated | Key-value store of asset data |

--- a/docs/asset.md
+++ b/docs/asset.md
@@ -18,35 +18,12 @@ represented by one or more [Google Protocol Buffers](https://developers.google.c
 
 For specific asset types, use a domain-specific protobuf, such as a [`Loan`](loan#loan-1), in the `kv` map.
 
-
-Example:
-```json
-{
-  "id": "c6978d46-3c3e-4175-a0d2-8f8ce47e8bb6",
-  "type": "LOAN",
-  "description": "PERSONAL_LOAN LOAN-1234",
-  "kv": {
-    "loan": {
-      "typeUrl": "/tech.figure.asset.loan.Loan",
-      "id": "c6978d46-3c3e-4175-a0d2-8f8ce47e8bb6",
-      "originatorName": "Example Loan Company",
-      "originatorLoanId": "LOAN-1234",
-      "loanType": "PERSONAL_LOAN",
-      "terms": {
-        "principalAmount": {
-          "amount": 10000.00,
-          "currency": "USD"
-        }
-      }
-    }
-  }
-} 
-```
+INSERT_EXAMPLE
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Required UUID identifier for this asset |
+| id | [tech.figure.util.v1beta1.UUID](#tech.figure.util.v1beta1.UUID) |  | Required UUID identifier for this asset |
 | type | [string](#string) |  | Optional user-defined type (e.g. LOAN, ART, PROPERTY TITLE, FUND, SHARE CLASS) |
 | description | [string](#string) |  | Optional user-defined description, title, name, etc. for display |
 | kv | [Asset.KvEntry](#tech.figure.asset.v1beta1.Asset.KvEntry) | repeated | Key-value store of asset data |

--- a/docs/docgen/examples/asset.json
+++ b/docs/docgen/examples/asset.json
@@ -4,7 +4,6 @@
   "description": "PERSONAL_LOAN LOAN-1234",
   "kv": {
     "loan": {
-      "typeUrl": "/tech.figure.asset.loan.Loan",
       "id": "c6978d46-3c3e-4175-a0d2-8f8ce47e8bb6",
       "originatorName": "Example Loan Company",
       "originatorLoanId": "LOAN-1234",
@@ -13,8 +12,25 @@
         "principalAmount": {
           "amount": 10000.00,
           "currency": "USD"
+        },
+        "totalAmount": {
+          "amount": 10200.00,
+          "currency": "USD"
+        },
+        "termInMonths": 12,
+        "interestRate": {
+          "value": 0.065
         }
-      }
+      },
+      "funding": {
+        "started": false,
+        "completed": false
+      },
+      "assetType": {
+        "supertype": "PERSONAL_LOAN"
+      },
+      "uli": "LEI456123456123456123456123",
+      "originatorUuid": "00000000-0000-0000-0000-000000000000"
     }
   }
 }

--- a/docs/docgen/examples/loan.json
+++ b/docs/docgen/examples/loan.json
@@ -7,6 +7,23 @@
     "principalAmount": {
       "amount": 10000.00,
       "currency": "USD"
+    },
+    "totalAmount": {
+      "amount": 10200.00,
+      "currency": "USD"
+    },
+    "termInMonths": 12,
+    "interestRate": {
+      "value": 0.065
     }
-  }
-} 
+  },
+  "funding": {
+    "started": false,
+    "completed": false
+  },
+  "assetType": {
+    "supertype": "PERSONAL_LOAN"
+  },
+  "uli": "LEI456123456123456123456123",
+  "originatorUuid": "00000000-0000-0000-0000-000000000000"
+}

--- a/docs/loan.md
+++ b/docs/loan.md
@@ -115,9 +115,26 @@ Example:
     "principalAmount": {
       "amount": 10000.00,
       "currency": "USD"
+    },
+    "totalAmount": {
+      "amount": 10200.00,
+      "currency": "USD"
+    },
+    "termInMonths": 12,
+    "interestRate": {
+      "value": 0.065
     }
-  }
-}  
+  },
+  "funding": {
+    "started": false,
+    "completed": false
+  },
+  "assetType": {
+    "supertype": "PERSONAL_LOAN"
+  },
+  "uli": "LEI456123456123456123456123",
+  "originatorUuid": "00000000-0000-0000-0000-000000000000"
+} 
 ```
 
 
@@ -134,6 +151,8 @@ Example:
 | doc_meta | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Metadata about documents related to the loan (document files stored separately) |
 | signed_data | [tech.figure.util.v1beta1.SignedData](util#tech.figure.util.v1beta1.SignedData) | repeated | Digitally-signed-by-source data/documents |
 | asset_type | [tech.figure.util.v1beta1.AssetType](util#tech.figure.util.v1beta1.AssetType) |  | Specify loan type if none of the above types are used, e.g. PERSONAL_LOAN |
+| uli | [string](#string) |  | Universal Loan Identifier (ULI) is a unique number made up of 23 to 45 characters that begins with the loan originator's Legal Entity Identifier (LEI). An originator's LEI can be found by searching the [GLEIF Website](https://search.gleif.org/#/search/). |
+| originator_uuid | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Originator UUID identifier |
 | mortgage | [Mortgage](#tech.figure.loan.v1beta1.Mortgage) |  | Mortgage |
 | heloc | [Heloc](#tech.figure.loan.v1beta1.Heloc) |  | Home Equity Line of Credit |
 | student_loan | [StudentLoan](#tech.figure.loan.v1beta1.StudentLoan) |  | New or refinanced student loan |

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -13,7 +13,7 @@
 <a name="io.dartinc.registry.v1beta1.Controller"></a>
 
 ### Controller
-
+ENote controller
 
 
 | Field | Type | Label | Description |

--- a/docs/servicing.md
+++ b/docs/servicing.md
@@ -72,13 +72,13 @@ Loan state data (servicing data) at a point in time
 <a name="tech.figure.servicing.v1beta1.LoanStateMetadata"></a>
 
 ### LoanStateMetadata
-
+Metadata associated with a single loan state object stored in the object store
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Identifier unique to this document |
-| effective_time | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  |  |
+| id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Identifier unique to this loan state object |
+| effective_time | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Timestamp when this state was produced |
 | uri | [string](#string) |  | URI Location where document is hosted/located |
 | checksum | [tech.figure.util.v1beta1.Checksum](util#tech.figure.util.v1beta1.Checksum) |  | Hash or checksum of document bytes |
 

--- a/docs/servicing.md
+++ b/docs/servicing.md
@@ -132,6 +132,7 @@ Note: static data is possibly repeated elsewhere, but required here to make life
 | asset_type | [tech.figure.util.v1beta1.AssetType](util#tech.figure.util.v1beta1.AssetType) |  | Asset type (See docs/util.md) |
 | current_borrower_info | [tech.figure.util.v1beta1.Borrowers](util#tech.figure.util.v1beta1.Borrowers) |  | Borrower(s), co-signers, etc |
 | original_note_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Total unpaid principal balance when the note is signed |
+| doc_meta | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Metadata about documents related to the loan (document files stored separately) |
 | loan_state | [LoanStateMetadata](#tech.figure.servicing.v1beta1.LoanStateMetadata) | repeated | List of pointers to the objects containing LoanState messages |
 
 

--- a/docs/util.md
+++ b/docs/util.md
@@ -397,7 +397,7 @@ Describes a educational course of study toward a degree
 <a name="tech.figure.util.v1beta1.AssetType"></a>
 
 ### AssetType
-
+Asset types.
 
 
 | Field | Type | Label | Description |
@@ -492,7 +492,7 @@ In Java: Use `BigDecimal` to represent this value.
 <a name="tech.figure.util.v1beta1.Status"></a>
 
 ### Status
-A Status indicator along with the timestamp it became effective
+A Status indicator along with the timestamp it became effective.
 
 
 | Field | Type | Label | Description |

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -117,7 +117,7 @@ Validation request including a pointer to the snapshot of data requiring validat
 | ----- | ---- | ----- | ----------- |
 | request_id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Unique ID for the request |
 | effective_time | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Time the validation was requested |
-| snapshot_uri | [string](#string) |  | Pointer to the snapshot |
+| block_height | [int64](#int64) |  | Block height to perform validation against |
 | rule_set_id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | ID of rule set that needs to be executed |
 | description | [string](#string) |  | Description of the rule set |
 | validator_name | [string](#string) |  | Party that will run the validation |

--- a/src/main/proto/io/dartinc/registry/v1beta1/registry.proto
+++ b/src/main/proto/io/dartinc/registry/v1beta1/registry.proto
@@ -20,6 +20,9 @@ message ENote {
   repeated tech.figure.util.v1beta1.DocumentMetadata    assumption      = 20;                                           // Documents containing additional assumptions about the ENote
 }
 
+/**
+ENote controller
+ */
 message Controller {
   tech.figure.util.v1beta1.UUID                         controller_uuid = 1 [(validate.rules).message.required = true]; // ENote controller ID
   string                                                controller_name = 2 [(validate.rules).string.min_len = 1];      // ENote controller name

--- a/src/main/proto/tech/figure/loan/v1beta1/loan.proto
+++ b/src/main/proto/tech/figure/loan/v1beta1/loan.proto
@@ -38,6 +38,8 @@ message Loan {
   repeated tech.figure.util.v1beta1.DocumentMetadata  doc_meta           = 9;                                             // Metadata about documents related to the loan (document files stored separately)
   repeated tech.figure.util.v1beta1.SignedData        signed_data        = 10;                                            // Digitally-signed-by-source data/documents
   tech.figure.util.v1beta1.AssetType                  asset_type         = 11 [(validate.rules).message.required = true]; // Specify loan type if none of the above types are used, e.g. PERSONAL_LOAN
+  string                                              uli                = 12 [(validate.rules).string.min_len = 23, (validate.rules).string.max_len = 45]; // Universal Loan Identifier
+  tech.figure.util.v1beta1.UUID                       originator_uuid    = 13 [(validate.rules).message.required = true];  // Loan UUID identifier
   /*
   Loan-type specific information resides in one of the following loan types
    */

--- a/src/main/proto/tech/figure/loan/v1beta1/loan.proto
+++ b/src/main/proto/tech/figure/loan/v1beta1/loan.proto
@@ -38,8 +38,13 @@ message Loan {
   repeated tech.figure.util.v1beta1.DocumentMetadata  doc_meta           = 9;                                             // Metadata about documents related to the loan (document files stored separately)
   repeated tech.figure.util.v1beta1.SignedData        signed_data        = 10;                                            // Digitally-signed-by-source data/documents
   tech.figure.util.v1beta1.AssetType                  asset_type         = 11 [(validate.rules).message.required = true]; // Specify loan type if none of the above types are used, e.g. PERSONAL_LOAN
-  string                                              uli                = 12 [(validate.rules).string.min_len = 23, (validate.rules).string.max_len = 45]; // Universal Loan Identifier
-  tech.figure.util.v1beta1.UUID                       originator_uuid    = 13 [(validate.rules).message.required = true];  // Loan UUID identifier
+  /*
+    Universal Loan Identifier (ULI) is a unique number made up of 23 to 45 characters that begins with the loan
+    originator's Legal Entity Identifier (LEI).
+    An originator's LEI can be found by searching the [GLEIF Website](https://search.gleif.org/#/search/).
+  */
+  string                                              uli                = 12 [(validate.rules).string.min_len = 23, (validate.rules).string.max_len = 45];
+  tech.figure.util.v1beta1.UUID                       originator_uuid    = 13 [(validate.rules).message.required = true];  // Originator UUID identifier
   /*
   Loan-type specific information resides in one of the following loan types
    */

--- a/src/main/proto/tech/figure/loan/v1beta1/mismo_loan.proto
+++ b/src/main/proto/tech/figure/loan/v1beta1/mismo_loan.proto
@@ -22,7 +22,7 @@ message MISMOLoan {
     originator's Legal Entity Identifier (LEI).
     An originator's LEI can be found by searching the [GLEIF Website](https://search.gleif.org/#/search/).
   */
-  string                            uli   = 1 [(validate.rules).string.min_len = 23, (validate.rules).string.max_len = 45];
+  string                            uli   = 1 [(validate.rules).string.min_len = 23, (validate.rules).string.max_len = 45]; // Universal Loan Identifier
   google.protobuf.BytesValue        data  = 2 [(validate.rules).message.required = true]; // Byte array of the MISMO XML file
   map<string, google.protobuf.Any>  kv    = 99;// Key-value map allowing originator to provide additional data
 }
@@ -33,7 +33,7 @@ message MISMOLoanMetadata {
     originator's Legal Entity Identifier (LEI).
     An originator's LEI can be found by searching the [GLEIF Website](https://search.gleif.org/#/search/).
   */
-  string                                    uli       = 1 [(validate.rules).string.min_len = 23, (validate.rules).string.max_len = 45];
+  string                                    uli       = 1 [(validate.rules).string.min_len = 23, (validate.rules).string.max_len = 45]; // Universal Loan Identifier
   tech.figure.util.v1beta1.DocumentMetadata document  = 2; // Pointer to MISMO loan file in Object Store
   map<string, google.protobuf.Any>          kv        = 99; // Key-value map allowing originator to provide additional data
 }

--- a/src/main/proto/tech/figure/loan/v1beta1/mismo_loan.proto
+++ b/src/main/proto/tech/figure/loan/v1beta1/mismo_loan.proto
@@ -22,7 +22,7 @@ message MISMOLoan {
     originator's Legal Entity Identifier (LEI).
     An originator's LEI can be found by searching the [GLEIF Website](https://search.gleif.org/#/search/).
   */
-  string                            uli   = 1 [(validate.rules).string.min_len = 23, (validate.rules).string.max_len = 45]; // Universal Loan Identifier
+  string                            uli   = 1 [(validate.rules).string.min_len = 23, (validate.rules).string.max_len = 45];
   google.protobuf.BytesValue        data  = 2 [(validate.rules).message.required = true]; // Byte array of the MISMO XML file
   map<string, google.protobuf.Any>  kv    = 99;// Key-value map allowing originator to provide additional data
 }
@@ -33,7 +33,7 @@ message MISMOLoanMetadata {
     originator's Legal Entity Identifier (LEI).
     An originator's LEI can be found by searching the [GLEIF Website](https://search.gleif.org/#/search/).
   */
-  string                                    uli       = 1 [(validate.rules).string.min_len = 23, (validate.rules).string.max_len = 45]; // Universal Loan Identifier
+  string                                    uli       = 1 [(validate.rules).string.min_len = 23, (validate.rules).string.max_len = 45];
   tech.figure.util.v1beta1.DocumentMetadata document  = 2; // Pointer to MISMO loan file in Object Store
   map<string, google.protobuf.Any>          kv        = 99; // Key-value map allowing originator to provide additional data
 }

--- a/src/main/proto/tech/figure/loan/v1beta1/mortgage.proto
+++ b/src/main/proto/tech/figure/loan/v1beta1/mortgage.proto
@@ -125,5 +125,5 @@ message Recording {
   string                            state_recorded                = 12;
   string                            recordation_number            = 13;
   string                            mortgagee_of_record           = 14 [(validate.rules).string.min_len = 1]; // Mortgagee of record (DART, MERS, or lender)
-  string                            original_mortgagee_of_record  = 14 [(validate.rules).string.min_len = 1]; // Original mortgagee of record (DART, MERS, or lender)
+  string                            original_mortgagee_of_record  = 15 [(validate.rules).string.min_len = 1]; // Original mortgagee of record (DART, MERS, or lender)
 }

--- a/src/main/proto/tech/figure/loan/v1beta1/mortgage.proto
+++ b/src/main/proto/tech/figure/loan/v1beta1/mortgage.proto
@@ -111,17 +111,19 @@ message EscrowWithdrawPolicy {
 The registration of the mortgage in a public record by a government agency
  */
 message Recording {
-  tech.figure.util.v1beta1.UUID     recorded_document_id     = 1 [(validate.rules).message.required = true];
-  tech.figure.util.v1beta1.Status   recording_status         = 2;
-  google.protobuf.Timestamp recorded_timestamp       = 3;
-  string                    instrument_number        = 4;
-  tech.figure.util.v1beta1.Date     security_instrument_date = 5;
-  tech.figure.util.v1beta1.Date     county_recorded_date     = 6;
-  string                    document_number          = 7;
-  string                    book                     = 8;
-  string                    page                     = 9;
-  string                    county_recorded          = 10;
-  string                    town_recorded            = 11;
-  string                    state_recorded           = 12;
-  string                    recordation_number       = 13;
+  tech.figure.util.v1beta1.UUID     recorded_document_id          = 1 [(validate.rules).message.required = true];
+  tech.figure.util.v1beta1.Status   recording_status              = 2;
+  google.protobuf.Timestamp         recorded_timestamp            = 3;
+  string                            instrument_number             = 4;
+  tech.figure.util.v1beta1.Date     security_instrument_date      = 5;
+  tech.figure.util.v1beta1.Date     county_recorded_date          = 6;
+  string                            document_number               = 7;
+  string                            book                          = 8;
+  string                            page                          = 9;
+  string                            county_recorded               = 10;
+  string                            town_recorded                 = 11;
+  string                            state_recorded                = 12;
+  string                            recordation_number            = 13;
+  string                            mortgagee_of_record           = 14 [(validate.rules).string.min_len = 1]; // Mortgagee of record (DART, MERS, or lender)
+  string                            original_mortgagee_of_record  = 14 [(validate.rules).string.min_len = 1]; // Original mortgagee of record (DART, MERS, or lender)
 }

--- a/src/main/proto/tech/figure/servicing/v1beta1/loan_state.proto
+++ b/src/main/proto/tech/figure/servicing/v1beta1/loan_state.proto
@@ -32,9 +32,12 @@ message ServicingData {
 	repeated LoanStateMetadata          loan_state             = 10;                                           // List of pointers to the objects containing LoanState messages
 }
 
+/*
+Metadata associated with a single loan state object stored in the object store
+ */
 message LoanStateMetadata {
-  tech.figure.util.v1beta1.UUID       id              = 1 [(validate.rules).message.required = true]; // Identifier unique to this document
-  google.protobuf.Timestamp           effective_time  = 2;
+  tech.figure.util.v1beta1.UUID       id              = 1 [(validate.rules).message.required = true]; // Identifier unique to this loan state object
+  google.protobuf.Timestamp           effective_time  = 2;                                            // Timestamp when this state was produced
   string                              uri             = 3;                                            // URI Location where document is hosted/located
   tech.figure.util.v1beta1.Checksum   checksum        = 4;                                            // Hash or checksum of document bytes
 }

--- a/src/main/proto/tech/figure/util/v1beta1/types.proto
+++ b/src/main/proto/tech/figure/util/v1beta1/types.proto
@@ -54,7 +54,7 @@ message Decimal {
 }
 
 /*
-A Status indicator along with the timestamp it became effective
+A Status indicator along with the timestamp it became effective.
  */
 message Status {
   string                    status         = 1 [(validate.rules).string.min_len = 1]; // Status string is context-dependant
@@ -69,6 +69,9 @@ message Checksum {
   string algorithm = 2 [(validate.rules).string.min_len = 1]; // Checksum algorithm, e.g. MD5, SHA256
 }
 
+/**
+Asset types.
+ */
 message AssetType {
   string supertype = 1 [(validate.rules).string.min_len = 1]; // The supertype of an asset (e.g. MORTGAGE, HELOC, PERSONAL_LOAN, AUTO_LOAN, NFT)
   string subtype   = 2; // The subtype of an asset (e.g. JUMBO, REFI, PARENT_REFI, DRAW)


### PR DESCRIPTION
Adding a few fields that were missing from the original definitions of a loan that DART would need should the originator choose to use that data model