### PR TITLE
Add means for additional document metadata

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -25,6 +25,35 @@ ENote controller
 
 
 
+<a name="io.dartinc.registry.v1beta1.DocumentRecordingGuidance"></a>
+
+### DocumentRecordingGuidance
+Metadata concerning how a collection of documents should be recorded on chain
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| designated_documents | [DocumentRecordingGuidance.DesignatedDocumentsEntry](#io.dartinc.registry.v1beta1.DocumentRecordingGuidance.DesignatedDocumentsEntry) | repeated | Markers for data |
+
+
+
+
+
+<a name="io.dartinc.registry.v1beta1.DocumentRecordingGuidance.DesignatedDocumentsEntry"></a>
+
+### DocumentRecordingGuidance.DesignatedDocumentsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [bool](#bool) |  |  |
+
+
+
+
+
 <a name="io.dartinc.registry.v1beta1.ENote"></a>
 
 ### ENote

--- a/src/main/proto/io/dartinc/registry/v1beta1/registry.proto
+++ b/src/main/proto/io/dartinc/registry/v1beta1/registry.proto
@@ -27,3 +27,11 @@ message Controller {
   tech.figure.util.v1beta1.UUID                         controller_uuid = 1 [(validate.rules).message.required = true]; // ENote controller ID
   string                                                controller_name = 2 [(validate.rules).string.min_len = 1];      // ENote controller name
 }
+
+/**
+Metadata concerning how a collection of documents should be recorded on chain
+ */
+message DocumentRecordingGuidance {
+  reserved 1, 2;                               // Available for future use
+  map <string, bool> designated_documents = 3; // Markers for data
+}

--- a/src/main/proto/tech/figure/loan/v1beta1/loan_documents.proto
+++ b/src/main/proto/tech/figure/loan/v1beta1/loan_documents.proto
@@ -4,11 +4,13 @@ package tech.figure.loan.v1beta1;
 
 option java_multiple_files = true;
 
+import "google/protobuf/any.proto";
 import "tech/figure/util/v1beta1/document.proto";
 
 /*
 List of loan documents for a single loan
  */
 message LoanDocuments {
-  repeated tech.figure.util.v1beta1.DocumentMetadata document = 1; // Individual document metadata w/ pointer to actual document
+  repeated tech.figure.util.v1beta1.DocumentMetadata document    = 1; // Individual document metadata w/ pointer to actual document
+  map<string, google.protobuf.Any>                   metadata_kv = 2; // Any additional metadata
 }


### PR DESCRIPTION
## Context
The contracts used by DART need a means of augmenting an input collection of document metadata with additional details. This provides a way to do so by modifying the `LoanDocuments` protobuf and then defining a new, slightly less generic protobuf that DART can use.
## Changes
- Add generic key-value map to `LoanDocuments` protobuf to support inclusion of any additional document metadata
- Define new protobuf for recording information about a collection of document metadata
- Update documentation accordingly, ~including changes from #15 which did not update the documentation~ (see comments below)
## Notes
Feedback on the schemes and names would be greatly appreciated