### PR TITLE
Generate ungenerated docs from v0.1.12 and fix its comment formatting

### DIFF
--- a/docs/util.md
+++ b/docs/util.md
@@ -466,8 +466,9 @@ In Java: Use <a href="https://www.joda.org/joda-money/">Joda Money</a>, `BigMone
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| amount | [double](#double) |  | Positive amounts only |
 | currency | [string](#string) |  | ISO 4217 3-digit currency code |
+| value | [string](#string) |  | Expects digits after a `.`, no + sign. Ex: 1.0, -1.0, 1, -1, 0.01. |
+| amount | [double](#double) |  | **Deprecated.** Superseded by `value`. |
 
 
 
@@ -483,7 +484,8 @@ In Java: Use `BigDecimal` to represent this value.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| value | [double](#double) |  | Value in the range [0,1], inclusive |
+| rate | [string](#string) |  | Expects digits after a `.`, no + sign. Ex: 1.0, -1.0, 1, -1, 0.01. |
+| value | [double](#double) |  | **Deprecated.** Superseded by `rate`. |
 
 
 

--- a/src/main/proto/tech/figure/util/v1beta1/types.proto
+++ b/src/main/proto/tech/figure/util/v1beta1/types.proto
@@ -33,8 +33,9 @@ In Java: Use `BigDecimal` to represent this value.
 message Rate {
   string rate  = 2 [(validate.rules).string.pattern = "^[-]?([0-9]+(?:[\\.][0-9]+)?|\\.[0-9]+)$"]; // Expects digits after a `.`, no + sign. Ex: 1.0, -1.0, 1, -1, 0.01.
 
-  // deprecated
-  double value = 1 [(validate.rules).double = {gte: 0; lte: 1 }, deprecated = true]; // Value in the range [0,1], inclusive
+  /* @exclude Deprecated fields */
+
+  double value = 1 [(validate.rules).double = {gte: 0; lte: 1 }, deprecated = true]; // Superseded by `rate`.
 }
 
 /*
@@ -46,8 +47,9 @@ message Money {
   string currency = 2 [(validate.rules).string.len = 3]; // ISO 4217 3-digit currency code
   string value    = 3 [(validate.rules).string.pattern = "^[-]?([0-9]+(?:[\\.][0-9]+)?|\\.[0-9]+)$"]; // Expects digits after a `.`, no + sign. Ex: 1.0, -1.0, 1, -1, 0.01.
 
-  // deprecated
-  double amount   = 1 [(validate.rules).double.gte = 0, deprecated = true]; // Positive amounts only
+  /* @exclude Deprecated fields */
+
+  double amount   = 1 [(validate.rules).double.gte = 0, deprecated = true]; // Superseded by `value`.
 }
 
 /*


### PR DESCRIPTION
## Context
Per [this comment](https://github.com/provenance-io/metadata-asset-model/pull/18#discussion_r955052684), fixing the bad formatting of the documentation that _should have been generated_ from the changes made in #15.
## Changes
- Add additional new line between the comment heading denoting deprecated fields and the fields below it, to prevent it from being interpreted as the field's description
- Add `@exclude` to the comment headings in question in order to reduce the chance of this happening again
- Run `make-docs.sh` to generate the documentation for the changes from #15