### PR TITLE
New investor fields: Added new fields for investor use [sc-181594]

### DIFF
--- a/docs/servicing.md
+++ b/docs/servicing.md
@@ -50,7 +50,7 @@ Loan state data (servicing data) at a point in time
 | deferred_principal | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Deferred Principal balance |
 | kv | [LoanState.KvEntry](#tech.figure.servicing.v1beta1.LoanState.KvEntry) | repeated | Additional loan state data for a user or tool-defined extension of state. Key is field name. Value is any proto Message. For scalar values, use <a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf">Protobuf Well-Known Types</a> |
 | credit_utilization_percentage | [tech.figure.util.v1beta1.Decimal](util#tech.figure.util.v1beta1.Decimal) |  | Current credit utilization % for HELOC's, for use by investors. (principal balance / credit limit) |
-| net_margin_rate               | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate)       |  | Net margin rate with discounts INCLUDED, for use by investors. (total rate - index rate) |
+| net_margin_rate | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | Net margin rate with discounts INCLUDED, for use by investors. (total rate - index rate) |
 
 
 

--- a/docs/servicing.md
+++ b/docs/servicing.md
@@ -49,6 +49,8 @@ Loan state data (servicing data) at a point in time
 | past_due_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Amount past due |
 | deferred_principal | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Deferred Principal balance |
 | kv | [LoanState.KvEntry](#tech.figure.servicing.v1beta1.LoanState.KvEntry) | repeated | Additional loan state data for a user or tool-defined extension of state. Key is field name. Value is any proto Message. For scalar values, use <a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf">Protobuf Well-Known Types</a> |
+| credit_utilization_percentage | [tech.figure.util.v1beta1.Decimal](util#tech.figure.util.v1beta1.Decimal) |  | Current credit utilization % for HELOC's, for use by investors. (principal balance / credit limit) |
+| net_margin_rate               | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate)       |  | Net margin rate with discounts INCLUDED, for use by investors. (total rate - index rate) |
 
 
 

--- a/src/main/proto/tech/figure/servicing/v1beta1/loan_state.proto
+++ b/src/main/proto/tech/figure/servicing/v1beta1/loan_state.proto
@@ -98,6 +98,9 @@ message LoanState {
   tech.figure.util.v1beta1.Money      principal_paid           = 28; // Sum of amount paid to principal
   tech.figure.util.v1beta1.Money      past_due_amount          = 29; // Amount past due
   tech.figure.util.v1beta1.Money      deferred_principal       = 30; // Deferred Principal balance
+  tech.figure.util.v1beta1.Decimal    credit_utilization_percentage = 31; // Current credit utilization % for HELOC's, for use by investors. (principal balance / credit limit)
+  tech.figure.util.v1beta1.Rate       net_margin_rate          = 32; // Net margin rate with discounts INCLUDED, for use by investors. (total rate - index rate)
+
 
   /*
     Additional loan state data for a user or tool-defined extension of state. Key is field name. Value is any proto Message.

--- a/src/main/proto/tech/figure/servicing/v1beta1/loan_state.proto
+++ b/src/main/proto/tech/figure/servicing/v1beta1/loan_state.proto
@@ -101,7 +101,6 @@ message LoanState {
   tech.figure.util.v1beta1.Decimal    credit_utilization_percentage = 31; // Current credit utilization % for HELOC's, for use by investors. (principal balance / credit limit)
   tech.figure.util.v1beta1.Rate       net_margin_rate          = 32; // Net margin rate with discounts INCLUDED, for use by investors. (total rate - index rate)
 
-
   /*
     Additional loan state data for a user or tool-defined extension of state. Key is field name. Value is any proto Message.
     For scalar values, use <a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf">Protobuf Well-Known Types</a>


### PR DESCRIPTION
Added credit utilization % and net_margin_rate to LoanState servicing fields. Adding these in LoanTape as well. I will make a PR in processor-loanstate to process these new fields as well. 

See other PRs:
https://github.com/FigureTechnologies/service-servicing/pull/4817

[Shortcut Ticket](https://app.shortcut.com/figure/story/181594/snapshot-draw-eligibility-add-credit-utilization-percent-add-net-margin)
