### PR TITLE
Mismo recording info

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @vwagner
+* @vwagner @dkneisly-figure @rpatel-figure

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,5 +2,9 @@
 
 - [Asset/NFT](asset.md)
 - [Loan](loan.md)
+  - [Mortgage](mortgage.md)
+  - [HELOC](heloc.md)
+- [MISMO Loan](mismo.md)
 - [Loan Servicing](servicing.md)
 - [Util](util.md)
+- [Registry](registry.md)

--- a/docs/docgen/examples/mismo.json
+++ b/docs/docgen/examples/mismo.json
@@ -1,0 +1,12 @@
+{
+  "typeUrl": "/tech.figure.asset.loan.MISMOLoanMetadata",
+  "uli": "LEI456123456123456123456123",
+  "document": {
+    "id": "",
+    "uri": "",
+    "fileName": "",
+    "contentType": "application/xml",
+    "documentType": "",
+    "checksum": ""
+  }
+}

--- a/docs/heloc.md
+++ b/docs/heloc.md
@@ -1,74 +1,32 @@
-# Digital Asset Registry Technology
+# HELOC
 <a name="top"></a>
 
 
 
-<a name="io/dartinc/registry/v1beta1/registry.proto"></a>
+<a name="tech/figure/loan/v1beta1/heloc.proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## io/dartinc/registry/v1beta1/registry.proto
+## tech/figure/loan/v1beta1/heloc.proto
 
 
 
-<a name="io.dartinc.registry.v1beta1.Controller"></a>
+<a name="tech.figure.loan.v1beta1.Heloc"></a>
 
-### Controller
-ENote controller
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| controller_uuid | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | ENote controller ID |
-| controller_name | [string](#string) |  | ENote controller name |
-
-
-
-
-
-<a name="io.dartinc.registry.v1beta1.DocumentRecordingGuidance"></a>
-
-### DocumentRecordingGuidance
-Metadata concerning how a collection of documents should be recorded on chain
+### Heloc
+A Home Equity Line of Credit (HELOC) Loan
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| designated_documents | [DocumentRecordingGuidance.DesignatedDocumentsEntry](#io.dartinc.registry.v1beta1.DocumentRecordingGuidance.DesignatedDocumentsEntry) | repeated | Markers for data |
-
-
-
-
-
-<a name="io.dartinc.registry.v1beta1.DocumentRecordingGuidance.DesignatedDocumentsEntry"></a>
-
-### DocumentRecordingGuidance.DesignatedDocumentsEntry
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [string](#string) |  |  |
-| value | [bool](#bool) |  |  |
-
-
-
-
-
-<a name="io.dartinc.registry.v1beta1.ENote"></a>
-
-### ENote
-Digital Asset Registry Technology (DART) ENote metadata
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| controller | [Controller](#io.dartinc.registry.v1beta1.Controller) |  | Identity of the ENote controller |
-| e_note | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) |  | Metadata of the authoritative copy of the ENote |
-| signed_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | Date the ENote was signed by the borrower |
-| vault_name | [string](#string) |  | Name of the eVault storing the Authoritative copy of the ENote |
-| modification | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Documents containing modifications to the ENote |
-| assumption | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Documents containing additional assumptions about the ENote |
-| borrower_signature_image | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Documents containing image signatures of all signers of the ENote |
+| lien_property | [tech.figure.util.v1beta1.Property](util#tech.figure.util.v1beta1.Property) |  | Subject property |
+| lien_position | [uint32](#uint32) |  | Lien position: 1 = first lien position, 2 or higher = junior lien position |
+| draw_term_in_months | [google.protobuf.UInt32Value](#google.protobuf.UInt32Value) |  | Total number of months the borrower can draw on the line |
+| draw_percentage | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | The maximum amount a borrower can redraw as a percent of the paid balance of the original draw (borrower cannot draw more than the original balance) |
+| recording_status | [tech.figure.util.v1beta1.Status](util#tech.figure.util.v1beta1.Status) |  | Loan recording status (e.g. PENDING, RECORDED) |
+| credit_limit_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | HELOC credit limit |
+| paid_draw_bonus_months | [int32](#int32) |  | Number of months draw period is extended by if paid off in original draw period |
+| static_draw_rate_flag | [bool](#bool) |  | If true, use interest_rate for any future draws. If false, use current prime rate |
+| recording_info | [Recording](#tech.figure.loan.v1beta1.Recording) |  | The registration of the lien in a public record by a government agency |
 
 
 

--- a/docs/mismo.md
+++ b/docs/mismo.md
@@ -13,8 +13,8 @@
 <a name="tech.figure.loan.v1beta1.MISMOLoan"></a>
 
 ### MISMOLoan
-Loan originators may choose to simply upload a MISMO standardized loan package to store static loan data collected through
-their Loan Origination System. The current standard is MISMO 3.4.
+Loan originators may choose to simply upload a MISMO standardized Loan Package to store static loan data collected through
+their Loan Origination System. The current standard is MISMO v3.4.
 
 This data is generally not expected to change over time. The evolving state of the loan (commonly called "servicing data")
 is represented by the [`LoanState`](loan_state) proto.
@@ -24,6 +24,7 @@ is represented by the [`LoanState`](loan_state) proto.
 | ----- | ---- | ----- | ----------- |
 | uli | [string](#string) |  | Universal Loan Identifier (ULI) is a unique number made up of 23 to 45 characters that begins with the loan originator's Legal Entity Identifier (LEI). An originator's LEI can be found by searching the [GLEIF Website](https://search.gleif.org/#/search/). |
 | data | [google.protobuf.BytesValue](#google.protobuf.BytesValue) |  | Byte array of the MISMO XML file |
+| recording_info | [Recording](#tech.figure.loan.v1beta1.Recording) |  | The registration of the mortgage in a public record by a government agency |
 | kv | [MISMOLoan.KvEntry](#tech.figure.loan.v1beta1.MISMOLoan.KvEntry) | repeated | Key-value map allowing originator to provide additional data |
 
 
@@ -48,13 +49,33 @@ is represented by the [`LoanState`](loan_state) proto.
 <a name="tech.figure.loan.v1beta1.MISMOLoanMetadata"></a>
 
 ### MISMOLoanMetadata
+Like any other loan document, the MISMO Loan Package can be stored separately in an Object Store and referenced here.
 
+This is the most common scenario for loans in the Provenance/DART ecosystem.
+
+
+Example:
+```json
+{
+  "typeUrl": "/tech.figure.asset.loan.MISMOLoanMetadata",
+  "uli": "LEI456123456123456123456123",
+  "document": {
+    "id": "",
+    "uri": "",
+    "fileName": "",
+    "contentType": "application/xml",
+    "documentType": "",
+    "checksum": ""
+  }
+} 
+```
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | uli | [string](#string) |  | Universal Loan Identifier (ULI) is a unique number made up of 23 to 45 characters that begins with the loan originator's Legal Entity Identifier (LEI). An originator's LEI can be found by searching the [GLEIF Website](https://search.gleif.org/#/search/). |
 | document | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) |  | Pointer to MISMO loan file in Object Store |
+| recording_info | [Recording](#tech.figure.loan.v1beta1.Recording) |  | The registration of the mortgage in a public record by a government agency |
 | kv | [MISMOLoanMetadata.KvEntry](#tech.figure.loan.v1beta1.MISMOLoanMetadata.KvEntry) | repeated | Key-value map allowing originator to provide additional data |
 
 

--- a/docs/mortgage.md
+++ b/docs/mortgage.md
@@ -1,0 +1,213 @@
+# Mortgage
+<a name="top"></a>
+
+
+
+<a name="tech/figure/loan/v1beta1/mortgage.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## tech/figure/loan/v1beta1/mortgage.proto
+
+
+
+<a name="tech.figure.loan.v1beta1.ARM"></a>
+
+### ARM
+Terms and dates for an Adjustable-Rate Mortgage (ARM)
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| index | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  |  |
+| initial_fixed_rate_period_months | [uint32](#uint32) |  |  |
+| initial_payment_adj_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  |  |
+| initial_rate_adj_cap | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  |  |
+| initial_rate_adj_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  |  |
+| initial_rate_adj_floor | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  |  |
+| lifetime_rate_adj_cap | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  |  |
+| margin | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  |  |
+| max_rate | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  |  |
+| min_rate | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  |  |
+| next_rate_adj_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  |  |
+| subs_rate_adj_cap | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  |  |
+| subs_rate_adj_period_months | [uint32](#uint32) |  |  |
+
+
+
+
+
+<a name="tech.figure.loan.v1beta1.Escrow"></a>
+
+### Escrow
+Monies held in an account, typically by the servicer, for paying certain expenses related to the lien property,
+such as taxes and insurance.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| escrow_monthly_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Sum of all monthly escrow amounts paid by the borrower in addition to the monthly payment amount |
+| pre_paid_escrow_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Prepaid escrow (paid out at closing to insurance / tax entities) |
+| initial_escrow_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Initial/starting escrow balance (held in escrow account by the servicer for future use) |
+| insurance_coverage | [InsuranceEscrow](#tech.figure.loan.v1beta1.InsuranceEscrow) | repeated | Homeowner's insurance |
+| tax_escrow | [TaxEscrow](#tech.figure.loan.v1beta1.TaxEscrow) | repeated | Property tax escrow |
+| hoa | [HomeOwnersAssociationEscrow](#tech.figure.loan.v1beta1.HomeOwnersAssociationEscrow) |  | Home Owner's Association information and dues |
+
+
+
+
+
+<a name="tech.figure.loan.v1beta1.EscrowWithdrawPolicy"></a>
+
+### EscrowWithdrawPolicy
+Describes how and when funds are withdrawn from an escrow account to pay an item
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| first_withdraw_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | The initial withdraw date after funding |
+| withdraw_frequency | [string](#string) |  | How often funds are withdrawn from escrow account to pay this item e.g. MONTHLY, SEMIANNUAL, YEARLY |
+| withdraw_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Amount to be withdrawn at the given frequency |
+
+
+
+
+
+<a name="tech.figure.loan.v1beta1.HomeOwnersAssociationEscrow"></a>
+
+### HomeOwnersAssociationEscrow
+Detail about escrow withholding for a Home Owners' Association for the lien property
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| escrow_flag | [bool](#bool) |  | Indication whether HOA dues are part of escrow |
+| escrow_monthly_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | If escrow flag is set, the amount withheld from the loan payment for this item |
+| withdraw_policy | [EscrowWithdrawPolicy](#tech.figure.loan.v1beta1.EscrowWithdrawPolicy) |  | HOA dues payment policy |
+| contact_info | [tech.figure.util.v1beta1.ContactInformation](util#tech.figure.util.v1beta1.ContactInformation) |  | HOA contact information |
+
+
+
+
+
+<a name="tech.figure.loan.v1beta1.InsuranceEscrow"></a>
+
+### InsuranceEscrow
+Detail about escrow withholding for insurance related to the lien property
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| escrow_flag | [bool](#bool) |  | Indication whether loan is escrowed for this type of insurance |
+| escrow_monthly_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | If escrow flag is set, the amount withheld from the loan payment for this item |
+| type | [string](#string) |  | Type of insurance, e.g. HOMEOWNERS, FLOOD, EARTHQUAKE, CONDO, HOA, PMI, MIP |
+| coverage_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Amount for which the property is insured |
+| expiration_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | Policy expiration date |
+| policy_number | [string](#string) |  | Policy account number |
+| withdraw_policy | [EscrowWithdrawPolicy](#tech.figure.loan.v1beta1.EscrowWithdrawPolicy) |  | Insurance escrow payment policy |
+| start_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | Policy start date |
+| contact_info | [tech.figure.util.v1beta1.ContactInformation](util#tech.figure.util.v1beta1.ContactInformation) |  | Insurance company contact information |
+
+
+
+
+
+<a name="tech.figure.loan.v1beta1.Mortgage"></a>
+
+### Mortgage
+A home Mortgage loan
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| lien_property | [tech.figure.util.v1beta1.Property](util#tech.figure.util.v1beta1.Property) |  | Property for which this mortgage was obtained |
+| lien_position | [uint32](#uint32) |  | Lien position: 1 = first lien position, 2 or more = junior lien position |
+| cash_out_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Cash proceeds to the borrower from a cash out refinancing after all other loans to be paid by the mortgage proceeds have been satisfied |
+| arm_flag | [bool](#bool) |  | True if loan is an Adjustable Rate Mortgage |
+| arm | [ARM](#tech.figure.loan.v1beta1.ARM) |  | If Adjustable-Rate Mortgage, the ARM terms |
+| io_flag | [bool](#bool) |  | True if loan is an interest-only loan |
+| io_term_months | [uint32](#uint32) |  | Number of months mortgage is interest-only |
+| escrow_flag | [bool](#bool) |  | Escrow enabled flag: Indicates whether various home ownership expenses (taxes, insurance, HOA dues) are paid by the borrower directly or through an escrow account. Borrower paid=false, paid through escrow=true |
+| neg_am_flag | [bool](#bool) |  | True if negative amortization |
+| agency_eligible_flag | [bool](#bool) |  | Desktop Underwriter: true if agency eligible. If Jumbo, should be false |
+| agency_program | [string](#string) |  | If agency eligible, the program to which this loan complies (e.g. FNMA HB, FNMA, JUMBO) |
+| escrow | [Escrow](#tech.figure.loan.v1beta1.Escrow) |  | Items held in escrow for this loan |
+| recording_info | [Recording](#tech.figure.loan.v1beta1.Recording) |  | Mortgage county recording information |
+
+
+
+
+
+<a name="tech.figure.loan.v1beta1.Recording"></a>
+
+### Recording
+The registration of the mortgage in a public record by a government agency
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| recorded_document_id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  |  |
+| recording_status | [tech.figure.util.v1beta1.Status](util#tech.figure.util.v1beta1.Status) |  |  |
+| recorded_timestamp | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  |  |
+| instrument_number | [string](#string) |  |  |
+| security_instrument_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  |  |
+| county_recorded_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  |  |
+| document_number | [string](#string) |  |  |
+| book | [string](#string) |  |  |
+| page | [string](#string) |  |  |
+| county_recorded | [string](#string) |  |  |
+| town_recorded | [string](#string) |  |  |
+| state_recorded | [string](#string) |  |  |
+| recordation_number | [string](#string) |  |  |
+| mortgagee_of_record | [string](#string) |  | Mortgagee of record (DART, MERS, or lender) |
+| original_mortgagee_of_record | [string](#string) |  | Original mortgagee of record (DART, MERS, or lender) |
+
+
+
+
+
+<a name="tech.figure.loan.v1beta1.TaxEscrow"></a>
+
+### TaxEscrow
+Detail about escrow witholding for tax payments related to the lien property
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| escrow_flag | [bool](#bool) |  | Indication whether loan is escrowed for taxes |
+| escrow_monthly_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | If escrow flag is set, the amount withheld from the loan payment for this item |
+| tax_type | [string](#string) |  | Type of tax, e.g. COMBINED, CITY, COUNTY, SCHOOL, MISC, BONDS, HOA_DUES, MOBILE_HOME, GROUND_RENT, OTHER, DELINQUENT |
+| withdraw_policy | [EscrowWithdrawPolicy](#tech.figure.loan.v1beta1.EscrowWithdrawPolicy) |  | Tax escrow payment policy |
+| tax_year | [string](#string) |  | Initial tax year |
+| contact_info | [tech.figure.util.v1beta1.ContactInformation](util#tech.figure.util.v1beta1.ContactInformation) |  | Tax authority contact information |
+
+
+
+
+
+
+
+
+
+
+
+
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ | Java | Python | Go | C# | PHP | Ruby |
+| ----------- | ----- | --- | ---- | ------ | -- | -- | --- | ---- |
+| <a name="double" /> double |  | double | double | float | float64 | double | float | Float |
+| <a name="float" /> float |  | float | float | float | float32 | float | float | Float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum or Fixnum (as required) |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="bool" /> bool |  | bool | boolean | boolean | bool | bool | boolean | TrueClass/FalseClass |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode | string | string | string | String (UTF-8) |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str | []byte | ByteString | string | String (ASCII-8BIT) |

--- a/make-docs.sh
+++ b/make-docs.sh
@@ -31,6 +31,8 @@ cp -r build/extracted-include-protos/main/validate ${TMP_DIR}
 
 gen_doc "tech/figure/asset/v1beta1/asset.proto" "asset.md" "Asset (NFT)"
 gen_doc "tech/figure/loan/v1beta1/loan.proto" "loan.md" "Loan"
+gen_doc "tech/figure/loan/v1beta1/mortgage.proto" "mortgage.md" "Mortgage"
+gen_doc "tech/figure/loan/v1beta1/heloc.proto" "heloc.md" "HELOC"
 gen_doc "tech/figure/loan/v1beta1/mismo_loan.proto" "mismo.md" "MISMO Loan"
 gen_doc "tech/figure/validation/v1beta1/validation.proto" "validation.md" "Loan Validation"
 gen_doc "io/dartinc/registry/v1beta1/registry.proto" "registry.md" "Digital Asset Registry Technology"
@@ -49,5 +51,4 @@ sed -i '' -e 's/#tech.figure.util/util#tech.figure.util/g' docs/*.md
 
 gen_example docs/docgen/examples/asset.json docs/asset.md
 gen_example docs/docgen/examples/loan.json docs/loan.md
-
-
+gen_example docs/docgen/examples/mismo.json docs/mismo.md

--- a/src/main/proto/tech/figure/loan/v1beta1/heloc.proto
+++ b/src/main/proto/tech/figure/loan/v1beta1/heloc.proto
@@ -5,6 +5,7 @@ package tech.figure.loan.v1beta1;
 option java_multiple_files = true;
 
 import "google/protobuf/wrappers.proto";
+import "tech/figure/loan/v1beta1/mortgage.proto";
 import "tech/figure/util/v1beta1/property.proto";
 import "tech/figure/util/v1beta1/types.proto";
 
@@ -13,11 +14,12 @@ A Home Equity Line of Credit (HELOC) Loan
  */
 message Heloc {
   tech.figure.util.v1beta1.Property lien_property          = 1; // Subject property
-  uint32                        lien_position          = 2; // Lien position: 1 = first lien position, 2 or higher = junior lien position
-  google.protobuf.UInt32Value   draw_term_in_months    = 3; // Total number of months the borrower can draw on the line
-  tech.figure.util.v1beta1.Rate         draw_percentage        = 4; // The maximum amount a borrower can redraw as a percent of the paid balance of the original draw (borrower cannot draw more than the original balance)
-  tech.figure.util.v1beta1.Status       recording_status       = 5; // Loan recording status (e.g. PENDING, RECORDED)
-  tech.figure.util.v1beta1.Money        credit_limit_amount    = 6; // HELOC credit limit
-  int32                         paid_draw_bonus_months = 7; // Number of months draw period is extended by if paid off in original draw period
-  bool                          static_draw_rate_flag  = 8; // If true, use interest_rate for any future draws. If false, use current prime rate
+  uint32                            lien_position          = 2; // Lien position: 1 = first lien position, 2 or higher = junior lien position
+  google.protobuf.UInt32Value       draw_term_in_months    = 3; // Total number of months the borrower can draw on the line
+  tech.figure.util.v1beta1.Rate     draw_percentage        = 4; // The maximum amount a borrower can redraw as a percent of the paid balance of the original draw (borrower cannot draw more than the original balance)
+  tech.figure.util.v1beta1.Status   recording_status       = 5; // Loan recording status (e.g. PENDING, RECORDED)
+  tech.figure.util.v1beta1.Money    credit_limit_amount    = 6; // HELOC credit limit
+  int32                             paid_draw_bonus_months = 7; // Number of months draw period is extended by if paid off in original draw period
+  bool                              static_draw_rate_flag  = 8; // If true, use interest_rate for any future draws. If false, use current prime rate
+  Recording                         recording_info         = 9; // The registration of the lien in a public record by a government agency
 }

--- a/src/main/proto/tech/figure/loan/v1beta1/mismo_loan.proto
+++ b/src/main/proto/tech/figure/loan/v1beta1/mismo_loan.proto
@@ -6,12 +6,13 @@ option java_multiple_files = true;
 
 import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
+import "tech/figure/loan/v1beta1/mortgage.proto";
 import "tech/figure/util/v1beta1/document.proto";
 import "validate/validate.proto";
 
 /*
-Loan originators may choose to simply upload a MISMO standardized loan package to store static loan data collected through
-their Loan Origination System. The current standard is MISMO 3.4.
+Loan originators may choose to simply upload a MISMO standardized Loan Package to store static loan data collected through
+their Loan Origination System. The current standard is MISMO v3.4.
 
 This data is generally not expected to change over time. The evolving state of the loan (commonly called "servicing data")
 is represented by the [`LoanState`](loan_state) proto.
@@ -22,18 +23,27 @@ message MISMOLoan {
     originator's Legal Entity Identifier (LEI).
     An originator's LEI can be found by searching the [GLEIF Website](https://search.gleif.org/#/search/).
   */
-  string                            uli   = 1 [(validate.rules).string.min_len = 23, (validate.rules).string.max_len = 45];
-  google.protobuf.BytesValue        data  = 2 [(validate.rules).message.required = true]; // Byte array of the MISMO XML file
-  map<string, google.protobuf.Any>  kv    = 99;// Key-value map allowing originator to provide additional data
+  string                            uli             = 1 [(validate.rules).string.min_len = 23, (validate.rules).string.max_len = 45];
+  google.protobuf.BytesValue        data            = 2 [(validate.rules).message.required = true]; // Byte array of the MISMO XML file
+  Recording                         recording_info  = 3;                                            // The registration of the mortgage in a public record by a government agency
+  map<string, google.protobuf.Any>  kv              = 99;                                           // Key-value map allowing originator to provide additional data
 }
 
+/*
+Like any other loan document, the MISMO Loan Package can be stored separately in an Object Store and referenced here.
+
+This is the most common scenario for loans in the Provenance/DART ecosystem.
+
+INSERT_EXAMPLE
+ */
 message MISMOLoanMetadata {
   /*
     Universal Loan Identifier (ULI) is a unique number made up of 23 to 45 characters that begins with the loan
     originator's Legal Entity Identifier (LEI).
     An originator's LEI can be found by searching the [GLEIF Website](https://search.gleif.org/#/search/).
   */
-  string                                    uli       = 1 [(validate.rules).string.min_len = 23, (validate.rules).string.max_len = 45];
-  tech.figure.util.v1beta1.DocumentMetadata document  = 2; // Pointer to MISMO loan file in Object Store
-  map<string, google.protobuf.Any>          kv        = 99; // Key-value map allowing originator to provide additional data
+  string                                    uli             = 1 [(validate.rules).string.min_len = 23, (validate.rules).string.max_len = 45];
+  tech.figure.util.v1beta1.DocumentMetadata document        = 2;  // Pointer to MISMO loan file in Object Store
+  Recording                                 recording_info  = 3;  // The registration of the mortgage in a public record by a government agency
+  map<string, google.protobuf.Any>          kv              = 99; // Key-value map allowing originator to provide additional data
 }

--- a/src/main/proto/tech/figure/loan/v1beta1/mortgage.proto
+++ b/src/main/proto/tech/figure/loan/v1beta1/mortgage.proto
@@ -14,19 +14,19 @@ import "validate/validate.proto";
 A home Mortgage loan
  */
 message Mortgage {
-  tech.figure.util.v1beta1.Property lien_property        = 1 [(validate.rules).message.required = true]; // Property for which this mortgage was obtained
-  uint32                        lien_position        = 2 [(validate.rules).uint32.gt = 0];           // Lien position: 1 = first lien position, 2 or more = junior lien position
-  tech.figure.util.v1beta1.Money        cash_out_amount      = 3;                                            // Cash proceeds to the borrower from a cash out refinancing after all other loans to be paid by the mortgage proceeds have been satisfied
-  bool                          arm_flag             = 4;                                            // True if loan is an Adjustable Rate Mortgage
-  ARM                           arm                  = 5;                                            // If Adjustable-Rate Mortgage, the ARM terms
-  bool                          io_flag              = 6;                                            // True if loan is an interest-only loan
-  uint32                        io_term_months       = 7;                                            // Number of months mortgage is interest-only
-  bool                          escrow_flag          = 8;                                            // Escrow enabled flag: Indicates whether various home ownership expenses (taxes, insurance, HOA dues) are paid by the borrower directly or through an escrow account. Borrower paid=false, paid through escrow=true
-  bool                          neg_am_flag          = 9;                                            // True if negative amortization
-  bool                          agency_eligible_flag = 10;                                           // Desktop Underwriter: true if agency eligible. If Jumbo, should be false
-  string                        agency_program       = 11;                                           // If agency eligible, the program to which this loan complies (e.g. FNMA HB, FNMA, JUMBO)
-  Escrow                        escrow               = 12;                                           // Items held in escrow for this loan
-  Recording                     recording_info       = 13;                                           // Mortgage county recording information
+  tech.figure.util.v1beta1.Property   lien_property        = 1 [(validate.rules).message.required = true]; // Property for which this mortgage was obtained
+  uint32                              lien_position        = 2 [(validate.rules).uint32.gt = 0];           // Lien position: 1 = first lien position, 2 or more = junior lien position
+  tech.figure.util.v1beta1.Money      cash_out_amount      = 3;                                            // Cash proceeds to the borrower from a cash out refinancing after all other loans to be paid by the mortgage proceeds have been satisfied
+  bool                                arm_flag             = 4;                                            // True if loan is an Adjustable Rate Mortgage
+  ARM                                 arm                  = 5;                                            // If Adjustable-Rate Mortgage, the ARM terms
+  bool                                io_flag              = 6;                                            // True if loan is an interest-only loan
+  uint32                              io_term_months       = 7;                                            // Number of months mortgage is interest-only
+  bool                                escrow_flag          = 8;                                            // Escrow enabled flag: Indicates whether various home ownership expenses (taxes, insurance, HOA dues) are paid by the borrower directly or through an escrow account. Borrower paid=false, paid through escrow=true
+  bool                                neg_am_flag          = 9;                                            // True if negative amortization
+  bool                                agency_eligible_flag = 10;                                           // Desktop Underwriter: true if agency eligible. If Jumbo, should be false
+  string                              agency_program       = 11;                                           // If agency eligible, the program to which this loan complies (e.g. FNMA HB, FNMA, JUMBO)
+  Escrow                              escrow               = 12;                                           // Items held in escrow for this loan
+  Recording                           recording_info       = 13;                                           // Mortgage county recording information
 }
 
 /*
@@ -34,7 +34,7 @@ Terms and dates for an Adjustable-Rate Mortgage (ARM)
  */
 message ARM {
   tech.figure.util.v1beta1.Rate index                            = 1;
-  uint32                initial_fixed_rate_period_months = 2;
+  uint32                        initial_fixed_rate_period_months = 2;
   tech.figure.util.v1beta1.Date initial_payment_adj_date         = 3;
   tech.figure.util.v1beta1.Rate initial_rate_adj_cap             = 4;
   tech.figure.util.v1beta1.Date initial_rate_adj_date            = 5;
@@ -45,7 +45,7 @@ message ARM {
   tech.figure.util.v1beta1.Rate min_rate                         = 10;
   tech.figure.util.v1beta1.Date next_rate_adj_date               = 11;
   tech.figure.util.v1beta1.Rate subs_rate_adj_cap                = 12;
-  uint32                subs_rate_adj_period_months      = 13;
+  uint32                        subs_rate_adj_period_months      = 13;
 }
 
 /*
@@ -56,18 +56,18 @@ message Escrow {
   tech.figure.util.v1beta1.Money escrow_monthly_amount  = 1; // Sum of all monthly escrow amounts paid by the borrower in addition to the monthly payment amount
   tech.figure.util.v1beta1.Money pre_paid_escrow_amount = 2; // Prepaid escrow (paid out at closing to insurance / tax entities)
   tech.figure.util.v1beta1.Money initial_escrow_amount  = 3; // Initial/starting escrow balance (held in escrow account by the servicer for future use)
-  repeated InsuranceEscrow     insurance_coverage     = 4; // Homeowner's insurance
-  repeated TaxEscrow     tax_escrow             = 5; // Property tax escrow
-  HomeOwnersAssociationEscrow  hoa                    = 6; // Home Owner's Association information and dues
+  repeated InsuranceEscrow       insurance_coverage     = 4; // Homeowner's insurance
+  repeated TaxEscrow             tax_escrow             = 5; // Property tax escrow
+  HomeOwnersAssociationEscrow    hoa                    = 6; // Home Owner's Association information and dues
 }
 
 /*
 Detail about escrow withholding for a Home Owners' Association for the lien property
  */
 message HomeOwnersAssociationEscrow {
-  bool                                escrow_flag           = 1; // Indication whether HOA dues are part of escrow
+  bool                                        escrow_flag           = 1; // Indication whether HOA dues are part of escrow
   tech.figure.util.v1beta1.Money              escrow_monthly_amount = 2; // If escrow flag is set, the amount withheld from the loan payment for this item
-  EscrowWithdrawPolicy                withdraw_policy       = 3; // HOA dues payment policy
+  EscrowWithdrawPolicy                        withdraw_policy       = 3; // HOA dues payment policy
   tech.figure.util.v1beta1.ContactInformation contact_info          = 4; // HOA contact information
 }
 
@@ -75,13 +75,13 @@ message HomeOwnersAssociationEscrow {
 Detail about escrow withholding for insurance related to the lien property
  */
 message InsuranceEscrow {
-  bool                                escrow_flag           = 1;  // Indication whether loan is escrowed for this type of insurance
+  bool                                        escrow_flag           = 1;  // Indication whether loan is escrowed for this type of insurance
   tech.figure.util.v1beta1.Money              escrow_monthly_amount = 2;  // If escrow flag is set, the amount withheld from the loan payment for this item
-  string                              type                  = 3;  // Type of insurance, e.g. HOMEOWNERS, FLOOD, EARTHQUAKE, CONDO, HOA, PMI, MIP
+  string                                      type                  = 3;  // Type of insurance, e.g. HOMEOWNERS, FLOOD, EARTHQUAKE, CONDO, HOA, PMI, MIP
   tech.figure.util.v1beta1.Money              coverage_amount       = 4;  // Amount for which the property is insured
   tech.figure.util.v1beta1.Date               expiration_date       = 5;  // Policy expiration date
-  string                              policy_number         = 7;  // Policy account number
-  EscrowWithdrawPolicy                withdraw_policy       = 8;  // Insurance escrow payment policy
+  string                                      policy_number         = 7;  // Policy account number
+  EscrowWithdrawPolicy                        withdraw_policy       = 8;  // Insurance escrow payment policy
   tech.figure.util.v1beta1.Date               start_date            = 9;  // Policy start date
   tech.figure.util.v1beta1.ContactInformation contact_info          = 10; // Insurance company contact information
 }
@@ -90,11 +90,11 @@ message InsuranceEscrow {
 Detail about escrow witholding for tax payments related to the lien property
  */
 message TaxEscrow {
-  bool                                escrow_flag           = 1; // Indication whether loan is escrowed for taxes
+  bool                                        escrow_flag           = 1; // Indication whether loan is escrowed for taxes
   tech.figure.util.v1beta1.Money              escrow_monthly_amount = 2; // If escrow flag is set, the amount withheld from the loan payment for this item
-  string                              tax_type              = 3; // Type of tax, e.g. COMBINED, CITY, COUNTY, SCHOOL, MISC, BONDS, HOA_DUES, MOBILE_HOME, GROUND_RENT, OTHER, DELINQUENT
-  EscrowWithdrawPolicy                withdraw_policy       = 4; // Tax escrow payment policy
-  string                              tax_year              = 5; // Initial tax year
+  string                                      tax_type              = 3; // Type of tax, e.g. COMBINED, CITY, COUNTY, SCHOOL, MISC, BONDS, HOA_DUES, MOBILE_HOME, GROUND_RENT, OTHER, DELINQUENT
+  EscrowWithdrawPolicy                        withdraw_policy       = 4; // Tax escrow payment policy
+  string                                      tax_year              = 5; // Initial tax year
   tech.figure.util.v1beta1.ContactInformation contact_info          = 6; // Tax authority contact information
 }
 
@@ -102,9 +102,9 @@ message TaxEscrow {
 Describes how and when funds are withdrawn from an escrow account to pay an item
  */
 message EscrowWithdrawPolicy {
-  tech.figure.util.v1beta1.Date  first_withdraw_date = 1; // The initial withdraw date after funding
-  string                 withdraw_frequency  = 2; // How often funds are withdrawn from escrow account to pay this item e.g. MONTHLY, SEMIANNUAL, YEARLY
-  tech.figure.util.v1beta1.Money withdraw_amount     = 3; // Amount to be withdrawn at the given frequency
+  tech.figure.util.v1beta1.Date   first_withdraw_date = 1; // The initial withdraw date after funding
+  string                          withdraw_frequency  = 2; // How often funds are withdrawn from escrow account to pay this item e.g. MONTHLY, SEMIANNUAL, YEARLY
+  tech.figure.util.v1beta1.Money  withdraw_amount     = 3; // Amount to be withdrawn at the given frequency
 }
 
 /*


### PR DESCRIPTION
1. Adding `recording_info` to both MISMO loan protos and HELOC proto, since that will be required to handle the security instrument in DART
2. Updating docs to reflect changes, add an example MISMOLoanMetadata proto, and to document the mortgage and heloc protos