### PR TITLE
Add release drafter for nicer release notes, fix test report error

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,74 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+  - title: '🛸 Enhancements'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+  - title: '📦 Dependency Updates'
+    label: 'dependencies'
+  - title: '📖 Documentation'
+    label: 'docs'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+autolabeler:
+  - label: 'enhancement'
+    branch:
+      - '/refactor\/.+/'
+    title:
+      - '/refactor/i'
+  - label: 'feature'
+    title:
+      - '/(add)|(feat)/i'
+  - label: 'fix'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'docs'
+    branch:
+      - '/(documentation)|(docs)\/.+/'
+    title:
+      - '/docs/i'
+  - label: 'dependencies'
+    title:
+      - '/update/i'
+exclude-contributors:
+  - 'renovate'
+  - 'renovate[bot]'
+replacers:
+  # For Figure contributors
+  - search: '/\[sc-(\d+)\]/gi'
+    replace: '[[sc-$1](https://app.shortcut.com/figure/story/$1)]'
+  - search: '/\[ch(\d+)\]/gi'
+    replace: '[[sc-$1](https://app.shortcut.com/figure/story/$1)]'
+  # For Renovate PRs
+  - search: '/@renovate(\[bot\])?$/gim'
+    replace: 'by [Renovate](https://github.com/renovatebot/renovate)'
+template: |
+  # Changelog
+  $CHANGES
+  # Notes
+  ## Required Updates
+  The relevant PRs and all work that needs to be done for this release to succeed (like updating dependencies) should be listed here
+  ## Contributors
+  $CONTRIBUTORS
+  ## Other
+  Other notes, if any, should be listed here

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,36 @@
+name: Release Drafter
+
+on:
+  # For creating draft releases
+  push:
+    branches:
+      - main
+  # For autolabeling PRs
+  pull_request:
+    types: [ synchronize, opened, reopened, ready_for_review, converted_to_draft ]
+  # For autolabeling PRs from forks
+  pull_request_target:
+    types: [ synchronize, opened, reopened, ready_for_review ]
+  # For updating the release draft (when run against main) & manually running the autolabeler (against any other branch)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    name: Update Release Draft
+    permissions:
+      # Write permission is required to create a GitHub release
+      contents: write
+      # Write permission is required for autolabeler
+      # Otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          # Allows the auto-labeler to run without adding unmerged PRs to the draft
+          disable-releaser: ${{ github.ref_name != 'main' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/test/kotlin/tech/figure/asset/v1beta1/AssetTest.kt
+++ b/src/test/kotlin/tech/figure/asset/v1beta1/AssetTest.kt
@@ -26,7 +26,7 @@ class AssetTest {
             kv.put(FileNFT.KEY_CONTENT_TYPE, "image/png".toProtoAny())
         }
 
-        println(asset1)
+        //println(asset1)
 
         val asset2 = Asset.parseFrom(asset1.toByteArray())
         val data = asset2.getKvOrThrow(FileNFT.KEY_BYTES)


### PR DESCRIPTION
## Context
Setting up release drafter so this repository can produce nicely organized release notes
## Changes
- Add release drafter workflow and configuration
- Comment out print statement to fix test report error caused by excessive test output
## Notes
- The release drafter workflow is expected to fail until it exists in the default branch, `main`