### PR TITLE
Add v1beta2 version of validation protos with metadata for results

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,3 +8,4 @@
 - [Loan Servicing](servicing.md)
 - [Util](util.md)
 - [Registry](registry.md)
+- [Validation](validation)

--- a/docs/asset.md
+++ b/docs/asset.md
@@ -62,7 +62,7 @@ Example:
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Required UUID identifier for this asset |
+| id | [tech.figure.util.v1beta1.UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Required UUID identifier for this asset |
 | type | [string](#string) |  | Optional user-defined type (e.g. LOAN, ART, PROPERTY TITLE, FUND, SHARE CLASS) |
 | description | [string](#string) |  | Optional user-defined description, title, name, etc. for display |
 | kv | [Asset.KvEntry](#tech.figure.asset.v1beta1.Asset.KvEntry) | repeated | Key-value store of asset data |

--- a/docs/heloc.md
+++ b/docs/heloc.md
@@ -18,12 +18,12 @@ A Home Equity Line of Credit (HELOC) Loan
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| lien_property | [tech.figure.util.v1beta1.Property](util#tech.figure.util.v1beta1.Property) |  | Subject property |
+| lien_property | [tech.figure.util.v1beta1.Property](util.md#tech.figure.util.v1beta1.Property) |  | Subject property |
 | lien_position | [uint32](#uint32) |  | Lien position: 1 = first lien position, 2 or higher = junior lien position |
 | draw_term_in_months | [google.protobuf.UInt32Value](#google.protobuf.UInt32Value) |  | Total number of months the borrower can draw on the line |
-| draw_percentage | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | The maximum amount a borrower can redraw as a percent of the paid balance of the original draw (borrower cannot draw more than the original balance) |
-| recording_status | [tech.figure.util.v1beta1.Status](util#tech.figure.util.v1beta1.Status) |  | Loan recording status (e.g. PENDING, RECORDED) |
-| credit_limit_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | HELOC credit limit |
+| draw_percentage | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  | The maximum amount a borrower can redraw as a percent of the paid balance of the original draw (borrower cannot draw more than the original balance) |
+| recording_status | [tech.figure.util.v1beta1.Status](util.md#tech.figure.util.v1beta1.Status) |  | Loan recording status (e.g. PENDING, RECORDED) |
+| credit_limit_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | HELOC credit limit |
 | paid_draw_bonus_months | [int32](#int32) |  | Number of months draw period is extended by if paid off in original draw period |
 | static_draw_rate_flag | [bool](#bool) |  | If true, use interest_rate for any future draws. If false, use current prime rate |
 | recording_info | [Recording](#tech.figure.loan.v1beta1.Recording) |  | The registration of the lien in a public record by a government agency |

--- a/docs/loan.md
+++ b/docs/loan.md
@@ -19,8 +19,8 @@ Data supplied by borrower during loan application and used by the underwriting p
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | loan_purpose | [string](#string) |  | Intended use of loan (e.g. Home improvement, Debt consolidation, Major purchase, Other purchase, Cash-out Refinance, Rate Refinance) |
-| income | [tech.figure.util.v1beta1.Income](util#tech.figure.util.v1beta1.Income) | repeated | Stated and/or verified income data |
-| credit_reports | [tech.figure.util.v1beta1.CreditReport](util#tech.figure.util.v1beta1.CreditReport) | repeated | Borrower credit reports |
+| income | [tech.figure.util.v1beta1.Income](util.md#tech.figure.util.v1beta1.Income) | repeated | Stated and/or verified income data |
+| credit_reports | [tech.figure.util.v1beta1.CreditReport](util.md#tech.figure.util.v1beta1.CreditReport) | repeated | Borrower credit reports |
 | kv | [ApplicationData.KvEntry](#tech.figure.loan.v1beta1.ApplicationData.KvEntry) | repeated | Additional application data |
 
 
@@ -51,10 +51,10 @@ multiple previous student loans are being consolidated and paid off. Each previo
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Disbursement identifier |
-| amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Amount to send |
-| disburse_account | [tech.figure.util.v1beta1.Account](util#tech.figure.util.v1beta1.Account) |  | Destination to send funds |
-| status | [tech.figure.util.v1beta1.Status](util#tech.figure.util.v1beta1.Status) |  | Status of sending funds for this disbursement: UNFUNDED, INITIATED, COMPLETED, CANCELLED |
+| id | [tech.figure.util.v1beta1.UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Disbursement identifier |
+| amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Amount to send |
+| disburse_account | [tech.figure.util.v1beta1.Account](util.md#tech.figure.util.v1beta1.Account) |  | Destination to send funds |
+| status | [tech.figure.util.v1beta1.Status](util.md#tech.figure.util.v1beta1.Status) |  | Status of sending funds for this disbursement: UNFUNDED, INITIATED, COMPLETED, CANCELLED |
 | started | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Time this disbursement was initiated |
 | completed | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Time this disbursement was completed |
 | kv | [Disbursement.KvEntry](#tech.figure.loan.v1beta1.Disbursement.KvEntry) | repeated | Additional process-specific data related to funding this disbursement |
@@ -86,7 +86,7 @@ Detail of the loan funding process
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| status | [tech.figure.util.v1beta1.Status](util#tech.figure.util.v1beta1.Status) |  | Status of loan funding process: e.g. UNFUNDED, INITIATED, FUNDED, CANCELLED |
+| status | [tech.figure.util.v1beta1.Status](util.md#tech.figure.util.v1beta1.Status) |  | Status of loan funding process: e.g. UNFUNDED, INITIATED, FUNDED, CANCELLED |
 | started | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Time funding process was initiated |
 | completed | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Time funding process was completed |
 | disbursements | [Disbursement](#tech.figure.loan.v1beta1.Disbursement) | repeated | Detailed information about one or more monetary disbursements to borrower |
@@ -140,19 +140,19 @@ Example:
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Loan UUID identifier |
+| id | [tech.figure.util.v1beta1.UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Loan UUID identifier |
 | originator_name | [string](#string) |  | Human-readable name of the originating firm |
 | originator_loan_id | [string](#string) |  | Originator's internal loan identifier |
-| borrowers | [tech.figure.util.v1beta1.Borrowers](util#tech.figure.util.v1beta1.Borrowers) |  | Borrower(s), co-signers, etc |
+| borrowers | [tech.figure.util.v1beta1.Borrowers](util.md#tech.figure.util.v1beta1.Borrowers) |  | Borrower(s), co-signers, etc |
 | terms | [Terms](#tech.figure.loan.v1beta1.Terms) |  | Loan terms: amount, duration, rates |
 | funding | [Funding](#tech.figure.loan.v1beta1.Funding) |  | Funding detail |
 | app | [ApplicationData](#tech.figure.loan.v1beta1.ApplicationData) |  | Data collected by LOS loan application process and used for underwriting |
 | underwriting | [Underwriting](#tech.figure.loan.v1beta1.Underwriting) |  | Underwriting |
-| doc_meta | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Metadata about documents related to the loan (document files stored separately) |
-| signed_data | [tech.figure.util.v1beta1.SignedData](util#tech.figure.util.v1beta1.SignedData) | repeated | Digitally-signed-by-source data/documents |
-| asset_type | [tech.figure.util.v1beta1.AssetType](util#tech.figure.util.v1beta1.AssetType) |  | Specify loan type if none of the above types are used, e.g. PERSONAL_LOAN |
+| doc_meta | [tech.figure.util.v1beta1.DocumentMetadata](util.md#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Metadata about documents related to the loan (document files stored separately) |
+| signed_data | [tech.figure.util.v1beta1.SignedData](util.md#tech.figure.util.v1beta1.SignedData) | repeated | Digitally-signed-by-source data/documents |
+| asset_type | [tech.figure.util.v1beta1.AssetType](util.md#tech.figure.util.v1beta1.AssetType) |  | Specify loan type if none of the above types are used, e.g. PERSONAL_LOAN |
 | uli | [string](#string) |  | Universal Loan Identifier (ULI) is a unique number made up of 23 to 45 characters that begins with the loan originator's Legal Entity Identifier (LEI). An originator's LEI can be found by searching the [GLEIF Website](https://search.gleif.org/#/search/). |
-| originator_uuid | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Originator UUID identifier |
+| originator_uuid | [tech.figure.util.v1beta1.UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Originator UUID identifier |
 | mortgage | [Mortgage](#tech.figure.loan.v1beta1.Mortgage) |  | Mortgage |
 | heloc | [Heloc](#tech.figure.loan.v1beta1.Heloc) |  | Home Equity Line of Credit |
 | student_loan | [StudentLoan](#tech.figure.loan.v1beta1.StudentLoan) |  | New or refinanced student loan |
@@ -186,13 +186,13 @@ Milestone dates for the loan established at origination
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| initial_offer_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | Date loan was offered to borrower |
-| origination_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | Date the loan is closed (typically same as `signed_date`) |
-| signed_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | Date the Note is signed |
-| funding_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | Date originator sent funds to borrower |
-| first_payment_due_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | Date first payment is due from borrower |
-| grace_period_end_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | If loan has grace period, date grace period ends and repayment must begin |
-| amortization_start_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | Date amortization schedule starts and interest begins accrual |
+| initial_offer_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | Date loan was offered to borrower |
+| origination_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | Date the loan is closed (typically same as `signed_date`) |
+| signed_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | Date the Note is signed |
+| funding_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | Date originator sent funds to borrower |
+| first_payment_due_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | Date first payment is due from borrower |
+| grace_period_end_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | If loan has grace period, date grace period ends and repayment must begin |
+| amortization_start_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | Date amortization schedule starts and interest begins accrual |
 
 
 
@@ -206,10 +206,10 @@ Details of the payment requirements for the loan
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| first_payment_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | The amount of the first scheduled payment to be made by the borrower. Includes principal, interest, taxes, and insurance (if escrows are not waived) |
-| monthly_payment_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Principal and interest only (no escrow/fees) |
+| first_payment_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | The amount of the first scheduled payment to be made by the borrower. Includes principal, interest, taxes, and insurance (if escrows are not waived) |
+| monthly_payment_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Principal and interest only (no escrow/fees) |
 | payment_method | [string](#string) |  | Borrower-select method of payment (e.g. MANUAL or AUTOPAY) |
-| autopay_account | [tech.figure.util.v1beta1.Account](util#tech.figure.util.v1beta1.Account) |  | Populated if borrower has agreed to automated monthly payments |
+| autopay_account | [tech.figure.util.v1beta1.Account](util.md#tech.figure.util.v1beta1.Account) |  | Populated if borrower has agreed to automated monthly payments |
 
 
 
@@ -224,7 +224,7 @@ A discount on the interest rate for the loan
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | type | [string](#string) |  | Reason for the rate discount, e.g. AUTOPAY, CREDIT_UNION_MEMBERSHIP |
-| rate | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | Amount interest rate is reduced |
+| rate | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  | Amount interest rate is reduced |
 | included_in_margin | [bool](#bool) |  | Indicate whether a discount is included in the loan margin or not. E.g. autopay discount only applied if starting on autopay. |
 
 
@@ -239,15 +239,15 @@ The terms and conditions for a loan: interest rates, fees, dates, etc.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| principal_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Loan amount, not including fees or interest |
-| total_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Principal loan amount + origination fees |
+| principal_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Loan amount, not including fees or interest |
+| total_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Principal loan amount + origination fees |
 | term_in_months | [int32](#int32) |  | Loan term (duration) in months |
 | rate_type | [string](#string) |  | Interest rate type (e.g. fixed or floating) See InterestRateExpectedType |
-| interest_rate | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | Total interest rate for loan (margin_rate + index_rate - any rate discounts at time of origination) |
-| index_rate | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | Benchmarked indexed rate value |
+| interest_rate | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  | Total interest rate for loan (margin_rate + index_rate - any rate discounts at time of origination) |
+| index_rate | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  | Benchmarked indexed rate value |
 | index_rate_type | [string](#string) |  | Benchmarked index rate type (e.g. Prime, LIBOR) See IndexRateType |
-| fees | [tech.figure.util.v1beta1.Fee](util#tech.figure.util.v1beta1.Fee) | repeated | Fees charged to the loan, e.g. origination fee, application fee, annual fee |
-| interest_rate_cap | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | Maximum allow interest rate on the loan (most relevant to variable-rate loans) |
+| fees | [tech.figure.util.v1beta1.Fee](util.md#tech.figure.util.v1beta1.Fee) | repeated | Fees charged to the loan, e.g. origination fee, application fee, annual fee |
+| interest_rate_cap | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  | Maximum allow interest rate on the loan (most relevant to variable-rate loans) |
 | rate_discounts | [RateDiscount](#tech.figure.loan.v1beta1.RateDiscount) | repeated | All rate discounts available to this asset. |
 | payment | [Payment](#tech.figure.loan.v1beta1.Payment) |  | Details about initial and monthly payments |
 | dates | [LoanDates](#tech.figure.loan.v1beta1.LoanDates) |  | Original milestone dates for the loan |
@@ -266,13 +266,13 @@ Information derived during the underwriting process
 | ----- | ---- | ----- | ----------- |
 | effective_time | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Timestamp when underwriting was performed ("as of" date) |
 | version | [string](#string) |  | Underwriting software or algorithm version |
-| pre_loan_ltv | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | Loan-to-value ratio - value of loan divided by value of asset (i.e. property value) - prior to this loan |
-| pre_loan_cltv | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | Combined loan-to-value ration - sum of values of all loans divided by value of asset (i.e. property value) - prior to this loan |
-| pre_loan_dti | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | Pre-loan debt to income ratio |
-| post_loan_ltv | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | Loan-to-value ratio - value of loan divided by value of asset (i.e. property value) - after/including this loan |
-| post_loan_cltv | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | Combined loan-to-value ratio - sum of values of all loans divided by value of asset (i.e. property value) - after/including this loan |
-| post_loan_dti | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | Post-loan debt to income ratio |
-| payment_to_income | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | Ratio of monthly loan payment to monthly income |
+| pre_loan_ltv | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  | Loan-to-value ratio - value of loan divided by value of asset (i.e. property value) - prior to this loan |
+| pre_loan_cltv | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  | Combined loan-to-value ration - sum of values of all loans divided by value of asset (i.e. property value) - prior to this loan |
+| pre_loan_dti | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  | Pre-loan debt to income ratio |
+| post_loan_ltv | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  | Loan-to-value ratio - value of loan divided by value of asset (i.e. property value) - after/including this loan |
+| post_loan_cltv | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  | Combined loan-to-value ratio - sum of values of all loans divided by value of asset (i.e. property value) - after/including this loan |
+| post_loan_dti | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  | Post-loan debt to income ratio |
+| payment_to_income | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  | Ratio of monthly loan payment to monthly income |
 | kv | [Underwriting.KvEntry](#tech.figure.loan.v1beta1.Underwriting.KvEntry) | repeated | Additional underwriting calculations |
 
 

--- a/docs/mismo.md
+++ b/docs/mismo.md
@@ -74,7 +74,7 @@ Example:
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | uli | [string](#string) |  | Universal Loan Identifier (ULI) is a unique number made up of 23 to 45 characters that begins with the loan originator's Legal Entity Identifier (LEI). An originator's LEI can be found by searching the [GLEIF Website](https://search.gleif.org/#/search/). |
-| document | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) |  | Pointer to MISMO loan file in Object Store |
+| document | [tech.figure.util.v1beta1.DocumentMetadata](util.md#tech.figure.util.v1beta1.DocumentMetadata) |  | Pointer to MISMO loan file in Object Store |
 | recording_info | [Recording](#tech.figure.loan.v1beta1.Recording) |  | The registration of the mortgage in a public record by a government agency |
 | kv | [MISMOLoanMetadata.KvEntry](#tech.figure.loan.v1beta1.MISMOLoanMetadata.KvEntry) | repeated | Key-value map allowing originator to provide additional data |
 

--- a/docs/mortgage.md
+++ b/docs/mortgage.md
@@ -18,18 +18,18 @@ Terms and dates for an Adjustable-Rate Mortgage (ARM)
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| index | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  |  |
+| index | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  |  |
 | initial_fixed_rate_period_months | [uint32](#uint32) |  |  |
-| initial_payment_adj_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  |  |
-| initial_rate_adj_cap | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  |  |
-| initial_rate_adj_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  |  |
-| initial_rate_adj_floor | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  |  |
-| lifetime_rate_adj_cap | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  |  |
-| margin | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  |  |
-| max_rate | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  |  |
-| min_rate | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  |  |
-| next_rate_adj_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  |  |
-| subs_rate_adj_cap | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  |  |
+| initial_payment_adj_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  |  |
+| initial_rate_adj_cap | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  |  |
+| initial_rate_adj_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  |  |
+| initial_rate_adj_floor | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  |  |
+| lifetime_rate_adj_cap | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  |  |
+| margin | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  |  |
+| max_rate | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  |  |
+| min_rate | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  |  |
+| next_rate_adj_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  |  |
+| subs_rate_adj_cap | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  |  |
 | subs_rate_adj_period_months | [uint32](#uint32) |  |  |
 
 
@@ -45,9 +45,9 @@ such as taxes and insurance.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| escrow_monthly_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Sum of all monthly escrow amounts paid by the borrower in addition to the monthly payment amount |
-| pre_paid_escrow_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Prepaid escrow (paid out at closing to insurance / tax entities) |
-| initial_escrow_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Initial/starting escrow balance (held in escrow account by the servicer for future use) |
+| escrow_monthly_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Sum of all monthly escrow amounts paid by the borrower in addition to the monthly payment amount |
+| pre_paid_escrow_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Prepaid escrow (paid out at closing to insurance / tax entities) |
+| initial_escrow_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Initial/starting escrow balance (held in escrow account by the servicer for future use) |
 | insurance_coverage | [InsuranceEscrow](#tech.figure.loan.v1beta1.InsuranceEscrow) | repeated | Homeowner's insurance |
 | tax_escrow | [TaxEscrow](#tech.figure.loan.v1beta1.TaxEscrow) | repeated | Property tax escrow |
 | hoa | [HomeOwnersAssociationEscrow](#tech.figure.loan.v1beta1.HomeOwnersAssociationEscrow) |  | Home Owner's Association information and dues |
@@ -64,9 +64,9 @@ Describes how and when funds are withdrawn from an escrow account to pay an item
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| first_withdraw_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | The initial withdraw date after funding |
+| first_withdraw_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | The initial withdraw date after funding |
 | withdraw_frequency | [string](#string) |  | How often funds are withdrawn from escrow account to pay this item e.g. MONTHLY, SEMIANNUAL, YEARLY |
-| withdraw_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Amount to be withdrawn at the given frequency |
+| withdraw_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Amount to be withdrawn at the given frequency |
 
 
 
@@ -81,9 +81,9 @@ Detail about escrow withholding for a Home Owners' Association for the lien prop
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | escrow_flag | [bool](#bool) |  | Indication whether HOA dues are part of escrow |
-| escrow_monthly_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | If escrow flag is set, the amount withheld from the loan payment for this item |
+| escrow_monthly_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | If escrow flag is set, the amount withheld from the loan payment for this item |
 | withdraw_policy | [EscrowWithdrawPolicy](#tech.figure.loan.v1beta1.EscrowWithdrawPolicy) |  | HOA dues payment policy |
-| contact_info | [tech.figure.util.v1beta1.ContactInformation](util#tech.figure.util.v1beta1.ContactInformation) |  | HOA contact information |
+| contact_info | [tech.figure.util.v1beta1.ContactInformation](util.md#tech.figure.util.v1beta1.ContactInformation) |  | HOA contact information |
 
 
 
@@ -98,14 +98,14 @@ Detail about escrow withholding for insurance related to the lien property
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | escrow_flag | [bool](#bool) |  | Indication whether loan is escrowed for this type of insurance |
-| escrow_monthly_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | If escrow flag is set, the amount withheld from the loan payment for this item |
+| escrow_monthly_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | If escrow flag is set, the amount withheld from the loan payment for this item |
 | type | [string](#string) |  | Type of insurance, e.g. HOMEOWNERS, FLOOD, EARTHQUAKE, CONDO, HOA, PMI, MIP |
-| coverage_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Amount for which the property is insured |
-| expiration_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | Policy expiration date |
+| coverage_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Amount for which the property is insured |
+| expiration_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | Policy expiration date |
 | policy_number | [string](#string) |  | Policy account number |
 | withdraw_policy | [EscrowWithdrawPolicy](#tech.figure.loan.v1beta1.EscrowWithdrawPolicy) |  | Insurance escrow payment policy |
-| start_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | Policy start date |
-| contact_info | [tech.figure.util.v1beta1.ContactInformation](util#tech.figure.util.v1beta1.ContactInformation) |  | Insurance company contact information |
+| start_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | Policy start date |
+| contact_info | [tech.figure.util.v1beta1.ContactInformation](util.md#tech.figure.util.v1beta1.ContactInformation) |  | Insurance company contact information |
 
 
 
@@ -119,9 +119,9 @@ A home Mortgage loan
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| lien_property | [tech.figure.util.v1beta1.Property](util#tech.figure.util.v1beta1.Property) |  | Property for which this mortgage was obtained |
+| lien_property | [tech.figure.util.v1beta1.Property](util.md#tech.figure.util.v1beta1.Property) |  | Property for which this mortgage was obtained |
 | lien_position | [uint32](#uint32) |  | Lien position: 1 = first lien position, 2 or more = junior lien position |
-| cash_out_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Cash proceeds to the borrower from a cash out refinancing after all other loans to be paid by the mortgage proceeds have been satisfied |
+| cash_out_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Cash proceeds to the borrower from a cash out refinancing after all other loans to be paid by the mortgage proceeds have been satisfied |
 | arm_flag | [bool](#bool) |  | True if loan is an Adjustable Rate Mortgage |
 | arm | [ARM](#tech.figure.loan.v1beta1.ARM) |  | If Adjustable-Rate Mortgage, the ARM terms |
 | io_flag | [bool](#bool) |  | True if loan is an interest-only loan |
@@ -145,12 +145,12 @@ The registration of the mortgage in a public record by a government agency
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| recorded_document_id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  |  |
-| recording_status | [tech.figure.util.v1beta1.Status](util#tech.figure.util.v1beta1.Status) |  |  |
+| recorded_document_id | [tech.figure.util.v1beta1.UUID](util.md#tech.figure.util.v1beta1.UUID) |  |  |
+| recording_status | [tech.figure.util.v1beta1.Status](util.md#tech.figure.util.v1beta1.Status) |  |  |
 | recorded_timestamp | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  |  |
 | instrument_number | [string](#string) |  |  |
-| security_instrument_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  |  |
-| county_recorded_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  |  |
+| security_instrument_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  |  |
+| county_recorded_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  |  |
 | document_number | [string](#string) |  |  |
 | book | [string](#string) |  |  |
 | page | [string](#string) |  |  |
@@ -174,11 +174,11 @@ Detail about escrow witholding for tax payments related to the lien property
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | escrow_flag | [bool](#bool) |  | Indication whether loan is escrowed for taxes |
-| escrow_monthly_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | If escrow flag is set, the amount withheld from the loan payment for this item |
+| escrow_monthly_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | If escrow flag is set, the amount withheld from the loan payment for this item |
 | tax_type | [string](#string) |  | Type of tax, e.g. COMBINED, CITY, COUNTY, SCHOOL, MISC, BONDS, HOA_DUES, MOBILE_HOME, GROUND_RENT, OTHER, DELINQUENT |
 | withdraw_policy | [EscrowWithdrawPolicy](#tech.figure.loan.v1beta1.EscrowWithdrawPolicy) |  | Tax escrow payment policy |
 | tax_year | [string](#string) |  | Initial tax year |
-| contact_info | [tech.figure.util.v1beta1.ContactInformation](util#tech.figure.util.v1beta1.ContactInformation) |  | Tax authority contact information |
+| contact_info | [tech.figure.util.v1beta1.ContactInformation](util.md#tech.figure.util.v1beta1.ContactInformation) |  | Tax authority contact information |
 
 
 

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -18,7 +18,7 @@ ENote controller
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| controller_uuid | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | ENote controller ID |
+| controller_uuid | [tech.figure.util.v1beta1.UUID](util.md#tech.figure.util.v1beta1.UUID) |  | ENote controller ID |
 | controller_name | [string](#string) |  | ENote controller name |
 
 
@@ -63,12 +63,12 @@ Digital Asset Registry Technology (DART) ENote metadata
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | controller | [Controller](#io.dartinc.registry.v1beta1.Controller) |  | Identity of the ENote controller |
-| e_note | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) |  | Metadata of the authoritative copy of the ENote |
-| signed_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | Date the ENote was signed by the borrower |
+| e_note | [tech.figure.util.v1beta1.DocumentMetadata](util.md#tech.figure.util.v1beta1.DocumentMetadata) |  | Metadata of the authoritative copy of the ENote |
+| signed_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | Date the ENote was signed by the borrower |
 | vault_name | [string](#string) |  | Name of the eVault storing the Authoritative copy of the ENote |
-| modification | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Documents containing modifications to the ENote |
-| assumption | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Documents containing additional assumptions about the ENote |
-| borrower_signature_image | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Documents containing image signatures of all signers of the ENote |
+| modification | [tech.figure.util.v1beta1.DocumentMetadata](util.md#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Documents containing modifications to the ENote |
+| assumption | [tech.figure.util.v1beta1.DocumentMetadata](util.md#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Documents containing additional assumptions about the ENote |
+| borrower_signature_image | [tech.figure.util.v1beta1.DocumentMetadata](util.md#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Documents containing image signatures of all signers of the ENote |
 
 
 

--- a/docs/servicing.md
+++ b/docs/servicing.md
@@ -24,8 +24,8 @@ Note: "bucket" is used interchangeably with Allocation and AllocationType
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | allocation_type | [string](#string) |  | AllocationType or String of another type |
-| amount_owed | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Balance owed - if LedgerEntry adjustment, alters owed amounts without appearing as if a payment were made (no change to applied) |
-| amount_applied | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Amount paid so far - if LedgerEntry, shows portion of entry applied to a type (or requested to be applied to a type) |
+| amount_owed | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Balance owed - if LedgerEntry adjustment, alters owed amounts without appearing as if a payment were made (no change to applied) |
+| amount_applied | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Amount paid so far - if LedgerEntry, shows portion of entry applied to a type (or requested to be applied to a type) |
 
 
 
@@ -40,9 +40,9 @@ Ex: disbursement, payments, late fee, adjustment
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| entry_uuid | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Ledger entry UUID |
+| entry_uuid | [tech.figure.util.v1beta1.UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Ledger entry UUID |
 | ledger_entry_type | [string](#string) |  | See LedgerEntryType |
-| amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | derived amount based upon the AllocationType amount provider |
+| amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | derived amount based upon the AllocationType amount provider |
 | breakdown | [LedgerEntryBreakdown](#tech.figure.servicing.v1beta1.LedgerEntryBreakdown) |  | Per-asset allocations of ledger entry (entry need not apply to every asset) |
 | effective_breakdown | [LedgerEntryBreakdown](#tech.figure.servicing.v1beta1.LedgerEntryBreakdown) |  | "Final" breakdown as applied to the asset. Contains any adjustments caused by linked entries (ex: BACKDATED_ENTRY_ADJUSTMENT, REVERSAL_ADJUSTMENT) |
 | effective_time | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Time ledger entry applied to loan |
@@ -215,36 +215,36 @@ Loan state data (servicing data) at a point in time
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Loan State Identifier |
+| id | [tech.figure.util.v1beta1.UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Loan State Identifier |
 | effective_time | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Timestamp when this state was produced |
 | servicer_name | [string](#string) |  | Name of servicer for loan |
-| total_unpaid_prin_bal | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Total unpaid principal balance |
-| accrued_interest | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Total interest accrued to-date |
-| daily_int_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Accrued interest amount per day |
-| loan_status | [tech.figure.util.v1beta1.Status](util#tech.figure.util.v1beta1.Status) |  | Loan status, such as: IN REPAY 1-9 DAYS DELQ 10-29 DAYS DELQ 30-59 DAYS DELQ 60-89 DAYS DELQ 90+ DAYS DELQ PAID_CLOSED PAID_OPEN FORBEARANCE TRANSFERRED |
-| current_p_and_i | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Currently monthly loan payment amount including principal and interest |
-| current_interest_rate | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | The current interest rate used to calculate the principal and interest payment |
-| int_accrual_start_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | The date on which interest accrual began |
-| int_paid_through_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | The date through which interest is paid with the current payment. The effective date from which interest will be calculated for the application of the next payment. |
-| maturity_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | The date when a loan reaches maturity |
-| next_due_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | Date of next due payment for loan |
+| total_unpaid_prin_bal | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Total unpaid principal balance |
+| accrued_interest | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Total interest accrued to-date |
+| daily_int_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Accrued interest amount per day |
+| loan_status | [tech.figure.util.v1beta1.Status](util.md#tech.figure.util.v1beta1.Status) |  | Loan status, such as: IN REPAY 1-9 DAYS DELQ 10-29 DAYS DELQ 30-59 DAYS DELQ 60-89 DAYS DELQ 90+ DAYS DELQ PAID_CLOSED PAID_OPEN FORBEARANCE TRANSFERRED |
+| current_p_and_i | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Currently monthly loan payment amount including principal and interest |
+| current_interest_rate | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  | The current interest rate used to calculate the principal and interest payment |
+| int_accrual_start_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | The date on which interest accrual began |
+| int_paid_through_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | The date through which interest is paid with the current payment. The effective date from which interest will be calculated for the application of the next payment. |
+| maturity_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | The date when a loan reaches maturity |
+| next_due_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | Date of next due payment for loan |
 | days_delinquent | [int32](#int32) |  | Number of days delinquent |
 | remaining_term_months | [int32](#int32) |  | Remaining loan term in months |
-| servicing_fee_rate | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | The fee paid to the servicer, stated as a percentage of the outstanding loan balance |
-| apr | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | Annualized Percentage Rate of the loan |
+| servicing_fee_rate | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  | The fee paid to the servicer, stated as a percentage of the outstanding loan balance |
+| apr | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  | Annualized Percentage Rate of the loan |
 | autopay_flag | [bool](#bool) |  | If true, payments are automatically deducted from borrower's financial account |
-| deferred_int_balance | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Accumulated Interest balance since forbearance_begin_date |
-| delinquent_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | If delinquent, date first payment was missed that made the loan currently delinquent |
+| deferred_int_balance | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Accumulated Interest balance since forbearance_begin_date |
+| delinquent_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | If delinquent, date first payment was missed that made the loan currently delinquent |
 | days_forbearance | [uint32](#uint32) |  | Days elapsed since entering Forbearance |
-| forbearance_begin_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | Date forbearance period begins |
-| forbearance_end_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | Date forbearance period ends |
-| interest_paid | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Total interest paid to-date |
-| interest_rate_cap | [tech.figure.util.v1beta1.Rate](util#tech.figure.util.v1beta1.Rate) |  | Interest rate cap |
-| last_payment_date | [tech.figure.util.v1beta1.Date](util#tech.figure.util.v1beta1.Date) |  | Last payment received date |
-| monthly_payment_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | The minimum monthly payment amount that borrower needs to repay on the loan |
-| principal_paid | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Sum of amount paid to principal |
-| past_due_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Amount past due |
-| deferred_principal | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Deferred Principal balance |
+| forbearance_begin_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | Date forbearance period begins |
+| forbearance_end_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | Date forbearance period ends |
+| interest_paid | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Total interest paid to-date |
+| interest_rate_cap | [tech.figure.util.v1beta1.Rate](util.md#tech.figure.util.v1beta1.Rate) |  | Interest rate cap |
+| last_payment_date | [tech.figure.util.v1beta1.Date](util.md#tech.figure.util.v1beta1.Date) |  | Last payment received date |
+| monthly_payment_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | The minimum monthly payment amount that borrower needs to repay on the loan |
+| principal_paid | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Sum of amount paid to principal |
+| past_due_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Amount past due |
+| deferred_principal | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Deferred Principal balance |
 | ledger_entry | [LedgerEntry](#tech.figure.servicing.v1beta1.LedgerEntry) | repeated | Ledger Entries effective on this date |
 | kv | [LoanState.KvEntry](#tech.figure.servicing.v1beta1.LoanState.KvEntry) | repeated | Additional loan state data for a user or tool-defined extension of state. Key is field name. Value is any proto Message. For scalar values, use <a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf">Protobuf Well-Known Types</a> |
 
@@ -275,10 +275,10 @@ Metadata associated with a single loan state object stored in the object store
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Identifier unique to this loan state object |
+| id | [tech.figure.util.v1beta1.UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Identifier unique to this loan state object |
 | effective_time | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Timestamp when this state was produced |
 | uri | [string](#string) |  | URI Location where document is hosted/located |
-| checksum | [tech.figure.util.v1beta1.Checksum](util#tech.figure.util.v1beta1.Checksum) |  | Hash or checksum of document bytes |
+| checksum | [tech.figure.util.v1beta1.Checksum](util.md#tech.figure.util.v1beta1.Checksum) |  | Hash or checksum of document bytes |
 
 
 
@@ -326,11 +326,11 @@ Note: static data is possibly repeated elsewhere, but required here to make life
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| loan_id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Loan Identifier |
-| asset_type | [tech.figure.util.v1beta1.AssetType](util#tech.figure.util.v1beta1.AssetType) |  | Asset type (See docs/util.md) |
-| current_borrower_info | [tech.figure.util.v1beta1.Borrowers](util#tech.figure.util.v1beta1.Borrowers) |  | Borrower(s), co-signers, etc |
-| original_note_amount | [tech.figure.util.v1beta1.Money](util#tech.figure.util.v1beta1.Money) |  | Total unpaid principal balance when the note is signed |
-| doc_meta | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Metadata about documents related to the loan (document files stored separately) |
+| loan_id | [tech.figure.util.v1beta1.UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Loan Identifier |
+| asset_type | [tech.figure.util.v1beta1.AssetType](util.md#tech.figure.util.v1beta1.AssetType) |  | Asset type (See docs/util.md) |
+| current_borrower_info | [tech.figure.util.v1beta1.Borrowers](util.md#tech.figure.util.v1beta1.Borrowers) |  | Borrower(s), co-signers, etc |
+| original_note_amount | [tech.figure.util.v1beta1.Money](util.md#tech.figure.util.v1beta1.Money) |  | Total unpaid principal balance when the note is signed |
+| doc_meta | [tech.figure.util.v1beta1.DocumentMetadata](util.md#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Metadata about documents related to the loan (document files stored separately) |
 | loan_state | [LoanStateMetadata](#tech.figure.servicing.v1beta1.LoanStateMetadata) | repeated | List of pointers to the objects containing LoanState messages |
 
 
@@ -360,9 +360,9 @@ Identity of the loan servicer and sub-servicer, if using
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| servicer_id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Primary servicer ID |
+| servicer_id | [tech.figure.util.v1beta1.UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Primary servicer ID |
 | servicer_name | [string](#string) |  | Primary servicer name |
-| sub_servicer_id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Sub-servicer ID |
+| sub_servicer_id | [tech.figure.util.v1beta1.UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Sub-servicer ID |
 | sub_servicer_name | [string](#string) |  | Sub-servicer name |
 | kv | [ServicingRights.KvEntry](#tech.figure.servicing.v1beta1.ServicingRights.KvEntry) | repeated | Any additional data related to servicing rights |
 

--- a/docs/util.md
+++ b/docs/util.md
@@ -21,7 +21,7 @@ The Automated Clearing House protocol has been in use since 1974.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| account_type | [ACH.AccountType](util#tech.figure.util.v1beta1.ACH.AccountType) |  | CHECKING, SAVINGS, or OTHER |
+| account_type | [ACH.AccountType](util.md#tech.figure.util.v1beta1.ACH.AccountType) |  | CHECKING, SAVINGS, or OTHER |
 | owner_type | [string](#string) |  | If required for ACH, type of account, e.g. INDIVIDUAL or COMMERCIAL |
 
 
@@ -36,9 +36,9 @@ Represents an account where currency is held, either in a traditional financial 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| account_owner_id | [UUID](util#tech.figure.util.v1beta1.UUID) |  | UUID of the borrower/owner of the account (if loan, should match one of `Loan.borrowers` IDs) |
-| financial | [FinancialAccount](util#tech.figure.util.v1beta1.FinancialAccount) |  | Traditional financial account, e.g. bank account |
-| provenance | [ProvenanceAccount](util#tech.figure.util.v1beta1.ProvenanceAccount) |  | Provenance Blockchain account |
+| account_owner_id | [UUID](util.md#tech.figure.util.v1beta1.UUID) |  | UUID of the borrower/owner of the account (if loan, should match one of `Loan.borrowers` IDs) |
+| financial | [FinancialAccount](util.md#tech.figure.util.v1beta1.FinancialAccount) |  | Traditional financial account, e.g. bank account |
+| provenance | [ProvenanceAccount](util.md#tech.figure.util.v1beta1.ProvenanceAccount) |  | Provenance Blockchain account |
 
 
 
@@ -52,12 +52,12 @@ Represents the location of an account at a financial institution, located by `ac
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [UUID](util#tech.figure.util.v1beta1.UUID) |  | Unique UUID identifier for this bank account |
+| id | [UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Unique UUID identifier for this bank account |
 | owner_name | [string](#string) |  | Name of the person who owns this account |
 | financial_institution | [string](#string) |  | Name of bank or financial institution |
 | account_number | [string](#string) |  | 4-17 digit Account number |
 | routing_number | [string](#string) |  | 9-digit Routing number |
-| movement | [MoneyMovement](util#tech.figure.util.v1beta1.MoneyMovement) | repeated | Instructions for moving money from this account |
+| movement | [MoneyMovement](util.md#tech.figure.util.v1beta1.MoneyMovement) | repeated | Instructions for moving money from this account |
 
 
 
@@ -71,8 +71,8 @@ Specification of how money may be sent to this account: ACH or wire transfer (do
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| ach | [ACH](util#tech.figure.util.v1beta1.ACH) |  | ACH |
-| wire | [WIRE](util#tech.figure.util.v1beta1.WIRE) |  | Wire transfer, domestic or international/SWIFT |
+| ach | [ACH](util.md#tech.figure.util.v1beta1.ACH) |  | ACH |
+| wire | [WIRE](util.md#tech.figure.util.v1beta1.WIRE) |  | Wire transfer, domestic or international/SWIFT |
 
 
 
@@ -105,7 +105,7 @@ international wire transfers.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | swift_id | [string](#string) |  | SWIFT bank account Id |
-| swift_bank_address | [Address](util#tech.figure.util.v1beta1.Address) |  | SWIFT bank mailing address |
+| swift_bank_address | [Address](util.md#tech.figure.util.v1beta1.Address) |  | SWIFT bank mailing address |
 
 
 
@@ -119,9 +119,9 @@ A wire transfer is an electronic transfer of funds via a network that is adminis
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| account_address | [Address](util#tech.figure.util.v1beta1.Address) |  | Account owner mailing address |
+| account_address | [Address](util.md#tech.figure.util.v1beta1.Address) |  | Account owner mailing address |
 | wire_instructions | [string](#string) |  | Wire-specific instructions |
-| swift_instructions | [SWIFT](util#tech.figure.util.v1beta1.SWIFT) |  | If international wire, include Swift instructions |
+| swift_instructions | [SWIFT](util.md#tech.figure.util.v1beta1.SWIFT) |  | If international wire, include Swift instructions |
 
 
 
@@ -187,9 +187,9 @@ Contact information for a third-party
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | name | [string](#string) |  | Name of contract person or company |
-| phone | [PhoneNumber](util#tech.figure.util.v1beta1.PhoneNumber) |  | Phone number |
+| phone | [PhoneNumber](util.md#tech.figure.util.v1beta1.PhoneNumber) |  | Phone number |
 | email | [string](#string) |  | RFC 1034-compliant email address |
-| address | [Address](util#tech.figure.util.v1beta1.Address) |  | Mailing address |
+| address | [Address](util.md#tech.figure.util.v1beta1.Address) |  | Mailing address |
 | fax | [string](#string) |  | Fax number |
 | url | [string](#string) |  | A web url relating to the contact - their homepage, their company's homepage, etc |
 
@@ -235,16 +235,16 @@ Detailed breakdown of an individual's credit history prepared by a credit bureau
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [UUID](util#tech.figure.util.v1beta1.UUID) |  | Id of this report |
-| borrower_id | [UUID](util#tech.figure.util.v1beta1.UUID) |  | Id of the borrower for whom this report was generated |
+| id | [UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Id of this report |
+| borrower_id | [UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Id of the borrower for whom this report was generated |
 | report_timestamp | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Date and time this report was generated |
 | credit_provider | [string](#string) |  | Name of credit report provider: EXPERIAN, TRANS_UNION, EQUIFAX |
-| pull_type | [CreditReport.CreditPullType](util#tech.figure.util.v1beta1.CreditReport.CreditPullType) |  | SOFT or HARD credit pull |
+| pull_type | [CreditReport.CreditPullType](util.md#tech.figure.util.v1beta1.CreditReport.CreditPullType) |  | SOFT or HARD credit pull |
 | credit_score | [uint32](#uint32) |  | Credit Score |
-| attributes | [CreditReport.AttributesEntry](util#tech.figure.util.v1beta1.CreditReport.AttributesEntry) | repeated | Attributes |
-| risk_models | [RiskModel](util#tech.figure.util.v1beta1.RiskModel) | repeated | Type of risk model used |
+| attributes | [CreditReport.AttributesEntry](util.md#tech.figure.util.v1beta1.CreditReport.AttributesEntry) | repeated | Attributes |
+| risk_models | [RiskModel](util.md#tech.figure.util.v1beta1.RiskModel) | repeated | Type of risk model used |
 | expiration | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Date credit report is valid until |
-| kv | [CreditReport.KvEntry](util#tech.figure.util.v1beta1.CreditReport.KvEntry) | repeated | Key-value store of credit report data |
+| kv | [CreditReport.KvEntry](util.md#tech.figure.util.v1beta1.CreditReport.KvEntry) | repeated | Key-value store of credit report data |
 
 
 
@@ -289,9 +289,9 @@ Detail of the risk model used in a credit report.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | score | [int32](#int32) |  |  |
-| factors | [RiskModel.FactorsEntry](util#tech.figure.util.v1beta1.RiskModel.FactorsEntry) | repeated |  |
-| risk_type | [RiskModel.RiskType](util#tech.figure.util.v1beta1.RiskModel.RiskType) |  |  |
-| other_type | [RiskModel.OtherRiskType](util#tech.figure.util.v1beta1.RiskModel.OtherRiskType) |  |  |
+| factors | [RiskModel.FactorsEntry](util.md#tech.figure.util.v1beta1.RiskModel.FactorsEntry) | repeated |  |
+| risk_type | [RiskModel.RiskType](util.md#tech.figure.util.v1beta1.RiskModel.RiskType) |  |  |
+| other_type | [RiskModel.OtherRiskType](util.md#tech.figure.util.v1beta1.RiskModel.OtherRiskType) |  |  |
 
 
 
@@ -394,12 +394,12 @@ actual contents of the file are stored elsewhere (described by the `uri`).
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [UUID](util#tech.figure.util.v1beta1.UUID) |  | Identifier unique to this document |
+| id | [UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Identifier unique to this document |
 | uri | [string](#string) |  | URI Location where document is hosted/located |
 | file_name | [string](#string) |  | Name of the original file, including file extension |
 | content_type | [string](#string) |  | Where possible, use MIME type, such as `application/pdf` or `application/xml` |
 | document_type | [string](#string) |  | Examples: HELOC_AGREEMENT, CREDIT_DISCLOSURE, PROOF_OF_RECORDED_DEED, TRANSFER_OF_SERVICING_RIGHTS, etc. |
-| checksum | [Checksum](util#tech.figure.util.v1beta1.Checksum) |  | Hash or checksum of document bytes |
+| checksum | [Checksum](util.md#tech.figure.util.v1beta1.Checksum) |  | Hash or checksum of document bytes |
 
 
 
@@ -413,16 +413,16 @@ actual contents of the file are stored elsewhere (described by the `uri`).
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| person_id | [UUID](util#tech.figure.util.v1beta1.UUID) |  |  |
-| notary | [Notary](util#tech.figure.util.v1beta1.Notary) |  |  |
+| person_id | [UUID](util.md#tech.figure.util.v1beta1.UUID) |  |  |
+| notary | [Notary](util.md#tech.figure.util.v1beta1.Notary) |  |  |
 | email | [string](#string) |  |  |
 | ip | [string](#string) |  |  |
 | user_agent | [string](#string) |  |  |
 | two_factor_signing_token | [string](#string) |  |  |
 | two_factor_timestamp | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  |  |
 | signing_timestamp | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  |  |
-| name | [Name](util#tech.figure.util.v1beta1.Name) |  |  |
-| witnesses | [Witness](util#tech.figure.util.v1beta1.Witness) | repeated |  |
+| name | [Name](util.md#tech.figure.util.v1beta1.Name) |  |  |
+| witnesses | [Witness](util.md#tech.figure.util.v1beta1.Witness) | repeated |  |
 
 
 
@@ -438,11 +438,11 @@ _Note: Actual document file/data is stored separately._
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| signed_document | [DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) |  | Fully-completed, electronically-signed document metadata |
-| unsigned_document | [DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) |  | Representation of document without signature. Usually a document template. |
-| electronic_signature | [ElectronicSignature](util#tech.figure.util.v1beta1.ElectronicSignature) |  | Customer's electronic signature data |
-| substitution_data | [ESignedDoc.SubstitutionDataEntry](util#tech.figure.util.v1beta1.ESignedDoc.SubstitutionDataEntry) | repeated | If `unsigned_document` is a template, this is the data inserted into the template. Key is the field name. |
-| signed_doc_checksum | [Checksum](util#tech.figure.util.v1beta1.Checksum) |  | Checksum (hash) of the signed version of the document |
+| signed_document | [DocumentMetadata](util.md#tech.figure.util.v1beta1.DocumentMetadata) |  | Fully-completed, electronically-signed document metadata |
+| unsigned_document | [DocumentMetadata](util.md#tech.figure.util.v1beta1.DocumentMetadata) |  | Representation of document without signature. Usually a document template. |
+| electronic_signature | [ElectronicSignature](util.md#tech.figure.util.v1beta1.ElectronicSignature) |  | Customer's electronic signature data |
+| substitution_data | [ESignedDoc.SubstitutionDataEntry](util.md#tech.figure.util.v1beta1.ESignedDoc.SubstitutionDataEntry) | repeated | If `unsigned_document` is a template, this is the data inserted into the template. Key is the field name. |
+| signed_doc_checksum | [Checksum](util.md#tech.figure.util.v1beta1.Checksum) |  | Checksum (hash) of the signed version of the document |
 
 
 
@@ -473,11 +473,11 @@ _Note: this distinct from a cryptographic [DigitalSignature](util#digitalsignatu
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| checksum | [Checksum](util#tech.figure.util.v1beta1.Checksum) |  | Checksum (hash) of the e-signature |
-| data | [ESigData](util#tech.figure.util.v1beta1.ESigData) | repeated |  |
-| person_id | [UUID](util#tech.figure.util.v1beta1.UUID) |  | Id of the person who signed the document (e.g. a borrower Id) |
-| asset_id | [UUID](util#tech.figure.util.v1beta1.UUID) |  | Id of the asset to which this document relates (e.g. a loan Id) |
-| document_id | [UUID](util#tech.figure.util.v1beta1.UUID) |  | Id of the signed document |
+| checksum | [Checksum](util.md#tech.figure.util.v1beta1.Checksum) |  | Checksum (hash) of the e-signature |
+| data | [ESigData](util.md#tech.figure.util.v1beta1.ESigData) | repeated |  |
+| person_id | [UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Id of the person who signed the document (e.g. a borrower Id) |
+| asset_id | [UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Id of the asset to which this document relates (e.g. a loan Id) |
+| document_id | [UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Id of the signed document |
 
 
 
@@ -491,8 +491,8 @@ Detail of the notary (person) who witnessed the signing and their commission inf
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| person_id | [UUID](util#tech.figure.util.v1beta1.UUID) |  |  |
-| name | [Name](util#tech.figure.util.v1beta1.Name) |  |  |
+| person_id | [UUID](util.md#tech.figure.util.v1beta1.UUID) |  |  |
+| name | [Name](util.md#tech.figure.util.v1beta1.Name) |  |  |
 | commission_id | [string](#string) |  |  |
 | commission_expiration | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  |  |
 | is_resident | [bool](#bool) |  |  |
@@ -509,8 +509,8 @@ Data or document digitally-signed by the source that created the data/document.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| meta | [DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) |  | Information about the data/document |
-| signature | [DigitalSignature](util#tech.figure.util.v1beta1.DigitalSignature) |  | Signature of vendor on this data/document |
+| meta | [DocumentMetadata](util.md#tech.figure.util.v1beta1.DocumentMetadata) |  | Information about the data/document |
+| signature | [DigitalSignature](util.md#tech.figure.util.v1beta1.DigitalSignature) |  | Signature of vendor on this data/document |
 | data | [google.protobuf.BytesValue](#google.protobuf.BytesValue) |  | Byte array of data/docum``ent contents |
 
 
@@ -525,8 +525,8 @@ A non-notary witness to the document signing
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| person_id | [UUID](util#tech.figure.util.v1beta1.UUID) |  |  |
-| name | [Name](util#tech.figure.util.v1beta1.Name) |  |  |
+| person_id | [UUID](util.md#tech.figure.util.v1beta1.UUID) |  |  |
+| name | [Name](util.md#tech.figure.util.v1beta1.Name) |  |  |
 
 
 
@@ -557,9 +557,9 @@ Describes a educational course of study toward a degree
 | ----- | ---- | ----- | ----------- |
 | school_name | [string](#string) |  | Name of educational institution |
 | school_code | [string](#string) |  | School code |
-| degree_level | [Education.DegreeLevel](util#tech.figure.util.v1beta1.Education.DegreeLevel) |  | Degree obtained or working toward |
-| start_date | [Date](util#tech.figure.util.v1beta1.Date) |  | Date program of study started |
-| end_date | [Date](util#tech.figure.util.v1beta1.Date) |  | Date program of study ended or planned to end |
+| degree_level | [Education.DegreeLevel](util.md#tech.figure.util.v1beta1.Education.DegreeLevel) |  | Degree obtained or working toward |
+| start_date | [Date](util.md#tech.figure.util.v1beta1.Date) |  | Date program of study started |
+| end_date | [Date](util.md#tech.figure.util.v1beta1.Date) |  | Date program of study ended or planned to end |
 | is_degree_complete | [bool](#bool) |  | True if course of study was completed and degree awarded |
 | graduation_month | [string](#string) |  | Month of graduation |
 | graduation_year | [string](#string) |  | Year of graduation |
@@ -616,8 +616,8 @@ Describes a fee charged, typically as part of a loan origination
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| rate | [Rate](util#tech.figure.util.v1beta1.Rate) |  | If a loan, describes the fee amount as a percentage of loan principal amount |
-| amount | [Money](util#tech.figure.util.v1beta1.Money) |  | Value amount of origination fee charged |
+| rate | [Rate](util.md#tech.figure.util.v1beta1.Rate) |  | If a loan, describes the fee amount as a percentage of loan principal amount |
+| amount | [Money](util.md#tech.figure.util.v1beta1.Money) |  | Value amount of origination fee charged |
 | type | [string](#string) |  | Fee type, e.g. ORIGINATION_FEE |
 | subtype | [string](#string) |  | Subtype allows variation of fee type. For an origination fee, subtype might be: NO_FEE, CAPITALIZED, UNCAPITALIZED_SPREAD, UNCAPITALIZED_UPFRONT |
 
@@ -651,8 +651,8 @@ Describes a fee charged, typically as part of a loan origination
 | account_name | [string](#string) |  | Account name |
 | account_mask | [string](#string) |  | Masked account number |
 | type | [string](#string) |  | Examples: 401K, IRA, ROTH_401K, ROTH, STOCK_PLAN, CD, CHECKING, SAVINGS, MONEY_MARKET, KEOGH, MUTUAL FUND |
-| historical_balances | [Balance](util#tech.figure.util.v1beta1.Balance) | repeated | Account balances over time |
-| current_balance_amount | [Money](util#tech.figure.util.v1beta1.Money) |  | Current account balance |
+| historical_balances | [Balance](util.md#tech.figure.util.v1beta1.Balance) | repeated | Account balances over time |
+| current_balance_amount | [Money](util.md#tech.figure.util.v1beta1.Money) |  | Current account balance |
 
 
 
@@ -666,9 +666,9 @@ Describes a fee charged, typically as part of a loan origination
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| retirement | [Money](util#tech.figure.util.v1beta1.Money) |  |  |
-| savings | [Money](util#tech.figure.util.v1beta1.Money) |  |  |
-| investment | [Money](util#tech.figure.util.v1beta1.Money) |  |  |
+| retirement | [Money](util.md#tech.figure.util.v1beta1.Money) |  |  |
+| savings | [Money](util.md#tech.figure.util.v1beta1.Money) |  |  |
+| investment | [Money](util.md#tech.figure.util.v1beta1.Money) |  |  |
 
 
 
@@ -683,7 +683,7 @@ Describes a fee charged, typically as part of a loan origination
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | vendor | [string](#string) |  | Firm holding this asset account(s) |
-| asset_accounts | [AssetAccount](util#tech.figure.util.v1beta1.AssetAccount) | repeated | One or more accounts held at this vendor |
+| asset_accounts | [AssetAccount](util.md#tech.figure.util.v1beta1.AssetAccount) | repeated | One or more accounts held at this vendor |
 | transaction_history_length_days | [int32](#int32) |  | Number of days of transaction history used in verification |
 
 
@@ -698,8 +698,8 @@ Describes a fee charged, typically as part of a loan origination
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| current | [Money](util#tech.figure.util.v1beta1.Money) |  | Account balance, current as of `date` |
-| date | [Date](util#tech.figure.util.v1beta1.Date) |  | Date on which this balance was accurate |
+| current | [Money](util.md#tech.figure.util.v1beta1.Money) |  | Account balance, current as of `date` |
+| date | [Date](util.md#tech.figure.util.v1beta1.Date) |  | Date on which this balance was accurate |
 
 
 
@@ -713,11 +713,11 @@ Describes a fee charged, typically as part of a loan origination
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| borrower_id | [UUID](util#tech.figure.util.v1beta1.UUID) |  | Id of borrower for whom these records pertain |
-| stated_yearly_income | [Money](util#tech.figure.util.v1beta1.Money) |  | Annual income as stated by the individual |
-| verified_yearly_income | [VerifiedIncome](util#tech.figure.util.v1beta1.VerifiedIncome) |  | Annual income as verified through some process |
-| income_sources | [IncomeSource](util#tech.figure.util.v1beta1.IncomeSource) | repeated | Borrower's sources of income (other than asset accounts) |
-| asset_income_sources | [AssetIncomeSource](util#tech.figure.util.v1beta1.AssetIncomeSource) | repeated | Income from asset accounts (e.g. investments, retirement, etc.) |
+| borrower_id | [UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Id of borrower for whom these records pertain |
+| stated_yearly_income | [Money](util.md#tech.figure.util.v1beta1.Money) |  | Annual income as stated by the individual |
+| verified_yearly_income | [VerifiedIncome](util.md#tech.figure.util.v1beta1.VerifiedIncome) |  | Annual income as verified through some process |
+| income_sources | [IncomeSource](util.md#tech.figure.util.v1beta1.IncomeSource) | repeated | Borrower's sources of income (other than asset accounts) |
+| asset_income_sources | [AssetIncomeSource](util.md#tech.figure.util.v1beta1.AssetIncomeSource) | repeated | Income from asset accounts (e.g. investments, retirement, etc.) |
 
 
 
@@ -732,8 +732,8 @@ Describes a fee charged, typically as part of a loan origination
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | source | [string](#string) |  | Name of employer or source of income (e.g. self-employed, child support, alimony) |
-| yearly_amount | [Money](util#tech.figure.util.v1beta1.Money) |  | Yearly income amount form this income source |
-| employment_status | [Status](util#tech.figure.util.v1beta1.Status) |  | E.g. FULL_TIME, PART_TIME, STUDENT, UNEMPLOYED |
+| yearly_amount | [Money](util.md#tech.figure.util.v1beta1.Money) |  | Yearly income amount form this income source |
+| employment_status | [Status](util.md#tech.figure.util.v1beta1.Status) |  | E.g. FULL_TIME, PART_TIME, STUDENT, UNEMPLOYED |
 | verification_timestamp | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Date/time at which employment was verified |
 
 
@@ -748,9 +748,9 @@ Describes a fee charged, typically as part of a loan origination
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| yearly_amount | [Money](util#tech.figure.util.v1beta1.Money) |  | Total borrower income, which has been verified through records |
-| date_verified | [Date](util#tech.figure.util.v1beta1.Date) |  | Date this income amount was verified |
-| verified_asset_depletion | [AssetDepletion](util#tech.figure.util.v1beta1.AssetDepletion) |  | Retirement/savings/investment account balances |
+| yearly_amount | [Money](util.md#tech.figure.util.v1beta1.Money) |  | Total borrower income, which has been verified through records |
+| date_verified | [Date](util.md#tech.figure.util.v1beta1.Date) |  | Date this income amount was verified |
+| verified_asset_depletion | [AssetDepletion](util.md#tech.figure.util.v1beta1.AssetDepletion) |  | Retirement/savings/investment account balances |
 | months_of_history | [int32](#int32) |  | Months of income that has been verified through records |
 | verification_methods_used | [string](#string) | repeated | Examples: PLAID_TRANSACTIONS, POINTSERV_PAYROLL, POINTSERV_TAX, EMPINFO, POINTSERV_W2, POINTSERV_1099_MISC, MANUAL_PAYSTUB, TRUEWORK_INSTANT, OTHER |
 
@@ -807,8 +807,8 @@ See `Person.party_type` to distinguish between borrower roles (e.g. primary vs c
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| primary | [Person](util#tech.figure.util.v1beta1.Person) |  | The main individual responsible for the loan |
-| additional | [Person](util#tech.figure.util.v1beta1.Person) | repeated | Co-borrowers and co-signers, if any |
+| primary | [Person](util.md#tech.figure.util.v1beta1.Person) |  | The main individual responsible for the loan |
+| additional | [Person](util.md#tech.figure.util.v1beta1.Person) | repeated | Co-borrowers and co-signers, if any |
 
 
 
@@ -840,17 +840,17 @@ Identifying information for a person.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [UUID](util#tech.figure.util.v1beta1.UUID) |  | Id for this person; may be referenced elsewhere in the model to link data to this individual |
+| id | [UUID](util.md#tech.figure.util.v1beta1.UUID) |  | Id for this person; may be referenced elsewhere in the model to link data to this individual |
 | party_type | [string](#string) |  | PRIMARY_BORROWER, COBORROWER, COSIGNER, etc. |
-| name | [Name](util#tech.figure.util.v1beta1.Name) |  | Name |
-| formerly_known_as | [Name](util#tech.figure.util.v1beta1.Name) | repeated | Populated if person has previous names or aliases (e.g. maiden name) |
-| dob | [Date](util#tech.figure.util.v1beta1.Date) |  | Date of birth |
-| phone_numbers | [PhoneNumber](util#tech.figure.util.v1beta1.PhoneNumber) | repeated | Contact phone numbers |
-| addresses | [Address](util#tech.figure.util.v1beta1.Address) | repeated | E.g. residential address or mailing address |
+| name | [Name](util.md#tech.figure.util.v1beta1.Name) |  | Name |
+| formerly_known_as | [Name](util.md#tech.figure.util.v1beta1.Name) | repeated | Populated if person has previous names or aliases (e.g. maiden name) |
+| dob | [Date](util.md#tech.figure.util.v1beta1.Date) |  | Date of birth |
+| phone_numbers | [PhoneNumber](util.md#tech.figure.util.v1beta1.PhoneNumber) | repeated | Contact phone numbers |
+| addresses | [Address](util.md#tech.figure.util.v1beta1.Address) | repeated | E.g. residential address or mailing address |
 | ssn | [string](#string) |  | Social Security Number |
 | email | [string](#string) |  | Email address |
 | citizenship | [string](#string) |  | Country of citizenship |
-| marital_status | [MaritalStatus](util#tech.figure.util.v1beta1.MaritalStatus) |  | Marital status |
+| marital_status | [MaritalStatus](util.md#tech.figure.util.v1beta1.MaritalStatus) |  | Marital status |
 | is_self_employed | [bool](#bool) |  | True if individual is self-employed |
 
 
@@ -896,8 +896,8 @@ Identifying information for a person.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| appraisal_amount | [Money](util#tech.figure.util.v1beta1.Money) |  |  |
-| appraisal_date | [Date](util#tech.figure.util.v1beta1.Date) |  |  |
+| appraisal_amount | [Money](util.md#tech.figure.util.v1beta1.Money) |  |  |
+| appraisal_date | [Date](util.md#tech.figure.util.v1beta1.Date) |  |  |
 
 
 
@@ -911,14 +911,14 @@ Identifying information for a person.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| address | [Address](util#tech.figure.util.v1beta1.Address) |  |  |
-| location | [PropertyLocation](util#tech.figure.util.v1beta1.PropertyLocation) |  |  |
-| site | [PropertySite](util#tech.figure.util.v1beta1.PropertySite) |  |  |
-| ownership | [PropertyOwnership](util#tech.figure.util.v1beta1.PropertyOwnership) |  |  |
+| address | [Address](util.md#tech.figure.util.v1beta1.Address) |  |  |
+| location | [PropertyLocation](util.md#tech.figure.util.v1beta1.PropertyLocation) |  |  |
+| site | [PropertySite](util.md#tech.figure.util.v1beta1.PropertySite) |  |  |
+| ownership | [PropertyOwnership](util.md#tech.figure.util.v1beta1.PropertyOwnership) |  |  |
 | type | [string](#string) |  |  |
 | usage | [string](#string) |  |  |
 | occupancy_type | [string](#string) |  |  |
-| appraisal | [Appraisal](util#tech.figure.util.v1beta1.Appraisal) |  |  |
+| appraisal | [Appraisal](util.md#tech.figure.util.v1beta1.Appraisal) |  |  |
 | number_of_units | [int32](#int32) |  |  |
 
 
@@ -977,7 +977,7 @@ Identifying information for a person.
 | ----- | ---- | ----- | ----------- |
 | owner_names | [string](#string) | repeated |  |
 | vesting_owners | [string](#string) | repeated |  |
-| address | [Address](util#tech.figure.util.v1beta1.Address) |  |  |
+| address | [Address](util.md#tech.figure.util.v1beta1.Address) |  |  |
 | phone_number | [string](#string) |  |  |
 | vesting_etal | [string](#string) |  |  |
 | vesting_ownership_right | [string](#string) |  |  |

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -1,0 +1,4 @@
+# Metadata Asset Model - Validation Documentation
+
+- [v1beta1](v1beta1.md)
+- [v1beta2](v1beta2.md)

--- a/docs/validation/v1beta1.md
+++ b/docs/validation/v1beta1.md
@@ -1,4 +1,4 @@
-# Loan Validation
+# Loan Validation (v1beta1)
 <a name="top"></a>
 
 
@@ -115,10 +115,10 @@ Validation request including a pointer to the snapshot of data requiring validat
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| request_id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Unique ID for the request |
+| request_id | [tech.figure.util.v1beta1.UUID](../util.md#tech.figure.util.v1beta1.UUID) |  | Unique ID for the request |
 | effective_time | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Time the validation was requested |
 | block_height | [int64](#int64) |  | Block height to perform validation against |
-| rule_set_id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | ID of rule set that needs to be executed |
+| rule_set_id | [tech.figure.util.v1beta1.UUID](../util.md#tech.figure.util.v1beta1.UUID) |  | ID of rule set that needs to be executed |
 | description | [string](#string) |  | Description of the rule set |
 | validator_name | [string](#string) |  | Party that will run the validation |
 | requester_name | [string](#string) |  | Party invoking the request for validation |
@@ -151,7 +151,7 @@ Input to the validation results p8e contract
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| request_id | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | Unique ID for the request - should match existing request |
+| request_id | [tech.figure.util.v1beta1.UUID](../util.md#tech.figure.util.v1beta1.UUID) |  | Unique ID for the request - should match existing request |
 | results | [ValidationResults](#tech.figure.validation.v1beta1.ValidationResults) |  | Validation results associated with the request |
 
 
@@ -166,14 +166,14 @@ Validation results that get stored alongside the validation request when validat
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| result_set_uuid | [tech.figure.util.v1beta1.UUID](util#tech.figure.util.v1beta1.UUID) |  | unique ID for the result set |
+| result_set_uuid | [tech.figure.util.v1beta1.UUID](../util.md#tech.figure.util.v1beta1.UUID) |  | unique ID for the result set |
 | result_set_effective_time | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | the date the validation was finalized |
 | result_set_provider | [string](#string) |  | name of the validator |
 | validation_exception_count | [int32](#int32) |  | Total count of exceptions |
 | validation_warning_count | [int32](#int32) |  | Total count of warnings |
 | validation_items | [ValidationItem](#tech.figure.validation.v1beta1.ValidationItem) | repeated | Individual rules that were executed |
-| policy_documents | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Related Documents like TPR Indemnification Policy, deligence scope |
-| rating_agency_grading | [tech.figure.util.v1beta1.DocumentMetadata](util#tech.figure.util.v1beta1.DocumentMetadata) |  | Document containing credit rating agency grades |
+| policy_documents | [tech.figure.util.v1beta1.DocumentMetadata](../util.md#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Related Documents like TPR Indemnification Policy, deligence scope |
+| rating_agency_grading | [tech.figure.util.v1beta1.DocumentMetadata](../util.md#tech.figure.util.v1beta1.DocumentMetadata) |  | Document containing credit rating agency grades |
 | kv | [ValidationResults.KvEntry](#tech.figure.validation.v1beta1.ValidationResults.KvEntry) | repeated | Additional fields from the validator |
 
 

--- a/docs/validation/v1beta2.md
+++ b/docs/validation/v1beta2.md
@@ -1,0 +1,253 @@
+# Loan Validation (v1beta2)
+<a name="top"></a>
+
+
+
+<a name="tech/figure/validation/v1beta2/validation.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## tech/figure/validation/v1beta2/validation.proto
+
+
+
+<a name="tech.figure.validation.v1beta2.LoanValidation"></a>
+
+### LoanValidation
+List of validation iterations.
+Each loan can go through several rounds of validation.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| iteration | [ValidationIteration](#tech.figure.validation.v1beta2.ValidationIteration) | repeated | An iteration of a validation request and its results |
+| kv | [LoanValidation.KvEntry](#tech.figure.validation.v1beta2.LoanValidation.KvEntry) | repeated | Additional fields |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta2.LoanValidation.KvEntry"></a>
+
+### LoanValidation.KvEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [google.protobuf.Any](#google.protobuf.Any) |  |  |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta2.ValidationItem"></a>
+
+### ValidationItem
+Individual rules that were executed, including the actual expression that was run
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| code | [string](#string) |  | Identifier for the rule |
+| label | [string](#string) |  | Short description of the rule |
+| description | [string](#string) |  | Long description of the rule |
+| expression | [string](#string) |  | Actual value, comparison operator, and expected value written as a formula or description of a comparison |
+| validation_outcome | [ValidationOutcome](#tech.figure.validation.v1beta2.ValidationOutcome) |  | Result of applying the rule, see enum |
+| kv | [ValidationItem.KvEntry](#tech.figure.validation.v1beta2.ValidationItem.KvEntry) | repeated | Additional information related to the rule |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta2.ValidationItem.KvEntry"></a>
+
+### ValidationItem.KvEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [google.protobuf.Any](#google.protobuf.Any) |  |  |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta2.ValidationIteration"></a>
+
+### ValidationIteration
+List of validation requests and corresponding response objects
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| request | [ValidationRequest](#tech.figure.validation.v1beta2.ValidationRequest) |  | A validation request |
+| results | [ValidationResultsMetadata](#tech.figure.validation.v1beta2.ValidationResultsMetadata) |  | Validation results corresponding to the given request |
+| kv | [ValidationIteration.KvEntry](#tech.figure.validation.v1beta2.ValidationIteration.KvEntry) | repeated | Additional fields |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta2.ValidationIteration.KvEntry"></a>
+
+### ValidationIteration.KvEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [google.protobuf.Any](#google.protobuf.Any) |  |  |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta2.ValidationRequest"></a>
+
+### ValidationRequest
+Validation request, including a pointer to the snapshot of data requiring validation
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| request_id | [tech.figure.util.v1beta1.UUID](../util.md#tech.figure.util.v1beta1.UUID) |  | Unique ID for the request |
+| effective_time | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Time that the validation was requested |
+| block_height | [int64](#int64) |  | A Provenance block height to perform validation against |
+| rule_set_id | [tech.figure.util.v1beta1.UUID](../util.md#tech.figure.util.v1beta1.UUID) |  | ID of rule set that needs to be executed |
+| description | [string](#string) |  | Description of the rule set |
+| validator_name | [string](#string) |  | Party that will run the validation |
+| requester_name | [string](#string) |  | Party invoking the request for validation |
+| kv | [ValidationRequest.KvEntry](#tech.figure.validation.v1beta2.ValidationRequest.KvEntry) | repeated | Additional fields from the requester |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta2.ValidationRequest.KvEntry"></a>
+
+### ValidationRequest.KvEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [google.protobuf.Any](#google.protobuf.Any) |  |  |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta2.ValidationResponse"></a>
+
+### ValidationResponse
+Submission of validation results for a specific validation request
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| request_id | [tech.figure.util.v1beta1.UUID](../util.md#tech.figure.util.v1beta1.UUID) |  | Unique ID for the request - should match an existing request |
+| results | [ValidationResultsMetadata](#tech.figure.validation.v1beta2.ValidationResultsMetadata) |  | Metadata of validation results associated with the request |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta2.ValidationResults"></a>
+
+### ValidationResults
+Validation results that should be created when validation is complete
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| result_set_uuid | [tech.figure.util.v1beta1.UUID](../util.md#tech.figure.util.v1beta1.UUID) |  | Unique ID for the result set |
+| result_set_effective_time | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | The date that the validation was finalized |
+| result_set_provider | [string](#string) |  | Name of the validator |
+| validation_exception_count | [int32](#int32) |  | Total count of exceptions |
+| validation_warning_count | [int32](#int32) |  | Total count of warnings |
+| validation_items | [ValidationItem](#tech.figure.validation.v1beta2.ValidationItem) | repeated | Individual rules that were executed |
+| policy_documents | [tech.figure.util.v1beta1.DocumentMetadata](../util.md#tech.figure.util.v1beta1.DocumentMetadata) | repeated | Related Documents, e.g. a TPR Indemnification Policy, a diligence scope, etc. |
+| rating_agency_grading | [tech.figure.util.v1beta1.DocumentMetadata](../util.md#tech.figure.util.v1beta1.DocumentMetadata) |  | Document containing credit rating agency grades |
+| kv | [ValidationResults.KvEntry](#tech.figure.validation.v1beta2.ValidationResults.KvEntry) | repeated | Additional fields from the validator |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta2.ValidationResults.KvEntry"></a>
+
+### ValidationResults.KvEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [google.protobuf.Any](#google.protobuf.Any) |  |  |
+
+
+
+
+
+<a name="tech.figure.validation.v1beta2.ValidationResultsMetadata"></a>
+
+### ValidationResultsMetadata
+Metadata of validation results that get stored when validation is complete
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [tech.figure.util.v1beta1.UUID](../util.md#tech.figure.util.v1beta1.UUID) |  | Identifier unique to this validation result set |
+| effective_time | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  | Timestamp of when these results were produced |
+| uri | [string](#string) |  | URI Location of where the results are hosted/located |
+| checksum | [tech.figure.util.v1beta1.Checksum](../util.md#tech.figure.util.v1beta1.Checksum) |  | Hash or checksum of the result bytes |
+
+
+
+
+
+
+
+<a name="tech.figure.validation.v1beta2.ValidationOutcome"></a>
+
+### ValidationOutcome
+Possible outcomes when applying a validation rule
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| UNKNOWN_TYPE | 0 |  |
+| EXCEPTION | 1 |  |
+| WARNING | 2 |  |
+| VALID | 3 |  |
+
+
+
+
+
+
+
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ | Java | Python | Go | C# | PHP | Ruby |
+| ----------- | ----- | --- | ---- | ------ | -- | -- | --- | ---- |
+| <a name="double" /> double |  | double | double | float | float64 | double | float | Float |
+| <a name="float" /> float |  | float | float | float | float32 | float | float | Float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum or Fixnum (as required) |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="bool" /> bool |  | bool | boolean | boolean | bool | bool | boolean | TrueClass/FalseClass |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode | string | string | string | String (UTF-8) |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str | []byte | ByteString | string | String (ASCII-8BIT) |

--- a/make-docs.sh
+++ b/make-docs.sh
@@ -18,9 +18,9 @@ fi
 
 function gen_doc() {
   docker run --rm -v "$(pwd)/docs":/out -v "$(pwd)"/${TMP_DIR}:/protos pseudomuto/protoc-gen-doc ${1} --doc_opt=/out/docgen/markdown.tmpl,${2}:validate/*
-  sed "${SEDOPTION[@]}" -e "s|Protocol Documentation|${3}|" docs/${2}
+  sed "${SEDOPTION[@]}" -e "s|Protocol Documentation|${3}|" "docs/${2}"
   # Get rid of extraneous lines in TOC list that make format wonky
-  sed "${SEDOPTION[@]}" -e '/^  $/d' docs/${2}
+  sed "${SEDOPTION[@]}" -e '/^  $/d' "docs/${2}"
 }
 
 function gen_example() {
@@ -34,13 +34,19 @@ mkdir -p ${TMP_DIR}
 cp -r src/main/proto/* ${TMP_DIR}
 cp -r build/extracted-include-protos/main/validate ${TMP_DIR}
 
+# Generate top-level documentation
 gen_doc "tech/figure/asset/v1beta1/asset.proto" "asset.md" "Asset (NFT)"
 gen_doc "tech/figure/loan/v1beta1/loan.proto" "loan.md" "Loan"
 gen_doc "tech/figure/loan/v1beta1/mortgage.proto" "mortgage.md" "Mortgage"
 gen_doc "tech/figure/loan/v1beta1/heloc.proto" "heloc.md" "HELOC"
 gen_doc "tech/figure/loan/v1beta1/mismo_loan.proto" "mismo.md" "MISMO Loan"
-gen_doc "tech/figure/validation/v1beta1/validation.proto" "validation.md" "Loan Validation"
 gen_doc "io/dartinc/registry/v1beta1/registry.proto" "registry.md" "Digital Asset Registry Technology"
+
+# Generate and organize versioned documentation
+gen_doc "tech/figure/validation/v1beta1/validation.proto" "validation_v1beta1.md" "Loan Validation (v1beta1)"
+mv -f "docs/validation_v1beta1.md" "docs/validation/v1beta1.md"
+gen_doc "tech/figure/validation/v1beta2/validation.proto" "validation_v1beta2.md" "Loan Validation (v1beta2)"
+mv -f "docs/validation_v1beta2.md" "docs/validation/v1beta2.md"
 
 pushd ${TMP_DIR} > /dev/null
 FILE_LIST=$( find tech/figure/servicing -name "*.proto" | sort -n)
@@ -52,7 +58,8 @@ FILE_LIST=$( find tech/figure/util -name "*.proto" | sort -n)
 popd > /dev/null
 gen_doc "${FILE_LIST}" "util.md" "Util"
 
-sed "${SEDOPTION[@]}" -e 's/#tech.figure.util/util#tech.figure.util/g' docs/*.md
+sed "${SEDOPTION[@]}" -e 's/#tech.figure.util/util.md#tech.figure.util/g' docs/*.md
+sed "${SEDOPTION[@]}" -e 's/#tech.figure.util/..\/util.md#tech.figure.util/g' docs/*/*.md
 
 gen_example docs/docgen/examples/asset.json docs/asset.md
 gen_example docs/docgen/examples/loan.json docs/loan.md

--- a/src/main/proto/tech/figure/validation/v1beta2/validation.proto
+++ b/src/main/proto/tech/figure/validation/v1beta2/validation.proto
@@ -1,0 +1,98 @@
+syntax = "proto3";
+
+package tech.figure.validation.v1beta2;
+
+option java_multiple_files = true;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/timestamp.proto";
+import "tech/figure/util/v1beta1/document.proto";
+import "tech/figure/util/v1beta1/types.proto";
+import "validate/validate.proto";
+
+/*
+List of validation iterations.
+Each loan can go through several rounds of validation.
+ */
+message LoanValidation {
+  repeated ValidationIteration     iteration =  1; // An iteration of a validation request and its results
+  map<string, google.protobuf.Any> kv        = 99; // Additional fields
+}
+
+/*
+List of validation requests and corresponding response objects
+ */
+message ValidationIteration {
+  ValidationRequest                request =  1; // A validation request
+  ValidationResultsMetadata        results =  2; // Validation results corresponding to the given request
+  map<string, google.protobuf.Any> kv      = 99; // Additional fields
+}
+
+/*
+Validation request, including a pointer to the snapshot of data requiring validation
+ */
+message ValidationRequest {
+  tech.figure.util.v1beta1.UUID    request_id     =  1 [(validate.rules).message.required = true];   // Unique ID for the request
+  google.protobuf.Timestamp        effective_time =  2 [(validate.rules).timestamp.required = true]; // Time that the validation was requested
+  int64                            block_height   =  3;                                              // A Provenance block height to perform validation against
+  tech.figure.util.v1beta1.UUID    rule_set_id    =  4;                                              // ID of rule set that needs to be executed
+  string                           description    =  5;                                              // Description of the rule set
+  string                           validator_name =  6 [(validate.rules).string.min_len = 1];        // Party that will run the validation
+  string                           requester_name =  7 [(validate.rules).string.min_len = 1];        // Party invoking the request for validation
+  map<string, google.protobuf.Any> kv             = 99;                                              // Additional fields from the requester
+}
+
+/*
+Submission of validation results for a specific validation request
+ */
+message ValidationResponse {
+  tech.figure.util.v1beta1.UUID request_id = 1; // Unique ID for the request - should match an existing request
+  ValidationResultsMetadata     results    = 2; // Metadata of validation results associated with the request
+}
+
+/*
+Metadata of validation results that get stored when validation is complete
+ */
+message ValidationResultsMetadata {
+  tech.figure.util.v1beta1.UUID     id             = 1 [(validate.rules).message.required = true]; // Identifier unique to this validation result set
+  google.protobuf.Timestamp         effective_time = 2;                                            // Timestamp of when these results were produced
+  string                            uri            = 3;                                            // URI Location of where the results are hosted/located
+  tech.figure.util.v1beta1.Checksum checksum       = 4;                                            // Hash or checksum of the result bytes
+}
+
+/*
+Validation results that should be created when validation is complete
+ */
+message ValidationResults {
+    tech.figure.util.v1beta1.UUID                      result_set_uuid            =  1; // Unique ID for the result set
+    google.protobuf.Timestamp                          result_set_effective_time  =  2; // The date that the validation was finalized
+    string                                             result_set_provider        =  3; // Name of the validator
+    int32                                              validation_exception_count = 10; // Total count of exceptions
+    int32                                              validation_warning_count   = 11; // Total count of warnings
+    repeated ValidationItem                            validation_items           = 20; // Individual rules that were executed
+    repeated tech.figure.util.v1beta1.DocumentMetadata policy_documents           = 30; // Related Documents, e.g. a TPR Indemnification Policy, a diligence scope, etc.
+    tech.figure.util.v1beta1.DocumentMetadata          rating_agency_grading      = 40; // Document containing credit rating agency grades
+    map<string, google.protobuf.Any>                   kv                         = 99; // Additional fields from the validator
+}
+
+/*
+Individual rules that were executed, including the actual expression that was run
+ */
+message ValidationItem {
+    string                           code               =  1; // Identifier for the rule
+    string                           label              =  2; // Short description of the rule
+    string                           description        =  3; // Long description of the rule
+    string                           expression         =  4; // Actual value, comparison operator, and expected value written as a formula or description of a comparison
+    ValidationOutcome                validation_outcome =  5; // Result of applying the rule, see enum
+    map<string, google.protobuf.Any> kv                 = 99; // Additional information related to the rule
+}
+
+/*
+Possible outcomes when applying a validation rule
+ */
+enum ValidationOutcome {
+    UNKNOWN_TYPE = 0;
+    EXCEPTION    = 1;
+    WARNING      = 2;
+    VALID        = 3;
+}


### PR DESCRIPTION
## Context
Despite our best efforts to keep models generic and extensible, it's difficult to define schema for loan validation usecases which suit everyone's needs. This PR redefines the existing loan validation protobufs under a new package, `v1beta2`, which instead use a simple metadata schema for validation results, so that results can simply be a pointer to an entry in an encrypted object store. It still redefines the `ValidationResults` protobuf verbatim, to act as a recommended schema for what `ValidationResultsMetadata` should point to.
## Changes
- Add new package `tech.figure.validation.v1beta2` which replaces usage of `ValidationResults` from `v1beta1` in wrapper protos into a simple metadata pointer object `ValidationResultsMetadata`
- Add entry for validation model documentation to root documentation README
- Move validation model documentation into own folder to separate its versions
- Explicitly specify file extension in Markdown links to `docs/util.md` in attempt to address wonky behavior when clicking said links
  - Doesn't seem to have fixed it entirely at least on my computer, still am redirected to seemingly arbitrary parts of `util.md`