### PR TITLE
Update README to reflect v1.0.0 and fix other outdated information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,82 @@
 # Provenance Blockchain Reference Use Case Data Model
 
-This repository contains the protobuf data model reference standard for [Provenance Blockchain Metadata module](https://docs.provenance.io/modules/metadata-module) 
-and [P8e Contract Execution Environment](https://docs.provenance.io/p8e/overview). 
+This repository contains a protobuf data model reference standard for the [Provenance Blockchain Metadata module](https://docs.provenance.io/modules/metadata-module)
+tailored for usage in the [P8e Contract Execution Environment](https://docs.provenance.io/p8e/overview).
 
-The model includes definitions for generic NFTs (Assets) as well as 
-business domain objects, such as loans and loan servicing data, and Java language-bindings.
+The model includes definitions for generic NFTs (Assets) as well as business domain objects — such as loans and loan servicing data — with language bindings for Java and Kotlin.
 
+## Status
+[![Build][build-badge]][build-workflow]
+[![stability-beta][stability-badge]][stability-info]
+[![License][license-badge]][license-url]
+[![LOC][loc-badge]][loc-url]
+### Publications
+[![Latest Release][release-badge]][release-latest]
+#### JAR
+[![Maven Artifact][publication-badge]][publication-url]
 
-### Maven
+#### Maven Usage
 
 ```xml
 <dependency>
-  <groupId>tech.figure.asset</groupId>
+  <groupId>io.provenance.model</groupId>
   <artifactId>metadata-asset-model</artifactId>
   <version>${version}</version>
 </dependency>
 ```
 
-### Gradle
-
+#### Gradle Usage
+**Groovy**
 ```groovy
-implementation 'tech.figure.asset:metadata-asset-model:${version}'
+implementation 'io.provenance.model:metadata-asset-model:${version}'
+```
+**Kotlin**
+```kotlin
+implementation("io.provenance.model:metadata-asset-model:$metadataAssetModelVersion")
 ```
 
+[build-badge]: https://img.shields.io/github/actions/workflow/status/provenance-io/metadata-asset-model/build.yml?branch=main&style=for-the-badge
+[build-workflow]: https://github.com/provenance-io/metadata-asset-model/actions/workflows/build.yml
+[stability-badge]: https://img.shields.io/badge/stability-beta-33bbff.svg?style=for-the-badge
+[stability-info]: https://github.com/mkenney/software-guides/blob/master/STABILITY-BADGES.md#beta
+[release-badge]: https://img.shields.io/github/v/tag/provenance-io/metadata-asset-model.svg?sort=semver&style=for-the-badge
+[release-latest]: https://github.com/provenance-io/metadata-asset-model/releases/latest
+[publication-badge]: https://maven-badges.herokuapp.com/maven-central/io.provenance.model/metadata-asset-model/badge.svg?style=for-the-badge
+[publication-url]: https://maven-badges.herokuapp.com/maven-central/io.provenance.model/metadata-asset-model
+[license-badge]: https://img.shields.io/github/license/provenance-io/metadata-asset-model.svg?style=for-the-badge
+[license-url]: https://github.com/provenance-io/metadata-asset-model/blob/main/LICENSE
+[loc-badge]: https://img.shields.io/tokei/lines/github/provenance-io/metadata-asset-model?style=for-the-badge
+[loc-url]: https://github.com/provenance-io/metadata-asset-model
 
-### [Model Documentation](docs/README.md)
+## Useful Links
 
-### Example Usage:
+- [Protocol Buffers Documentation](docs/README.md)
+- [P8e Contract Execution Environment Source Code](https://github.com/provenance-io/p8e-scope-sdk/)
+- [Associated P8e Scope Specification](https://github.com/provenance-io/loan-package-contracts/)
 
-This example shows how an NFT image file might be loaded into the P8e Contract Execution Environment, with the object
-hash store on the blockchain through the metadata module. Source code for this example is in
-[AssetTest](src/test/kotlin/tech.figure.proto/AssetTest.kt).
+## Example Usage
+
+This example shows how an NFT image file might be defined for usage in the P8e Contract Execution Environment, with the object hash stored on the blockchain through the metadata module.
+The full source code can be found in [AssetTest](src/test/kotlin/tech/figure/asset/v1beta1/AssetTest.kt).
 
 ```kotlin
-val file = File("src/test/data/logo.png")
+val file = File("src/test/resources/logo.png")
 val fileBytes = file.readBytes()
 
-val asset1 = AssetOuterClassBuilders.Asset {
+val asset1 = asset {
     id = UUID.randomUUID().toProtoUUID()
-    type = "FILE"
+    type = FileNFT.ASSET_TYPE
     description = file.name
-    putKv(FileNFT.KEY_FILENAME, file.name.toProtoAny())
-    putKv(FileNFT.KEY_SIZE, fileBytes.size.toLong().toProtoAny())
-    putKv(FileNFT.KEY_BYTES, fileBytes.toProtoAny())
-    putKv(FileNFT.KEY_CONTENT_TYPE, "image/png".toProtoAny())
+    kv.put(FileNFT.KEY_FILENAME, file.name.toProtoAny())
+    kv.put(FileNFT.KEY_SIZE, fileBytes.size.toLong().toProtoAny())
+    kv.put(FileNFT.KEY_BYTES, fileBytes.toProtoAny())
+    kv.put(FileNFT.KEY_CONTENT_TYPE, "image/png".toProtoAny())
 }
 ```
 
-The JSON representation of this asset would look like:
+The JSON representation of this asset would look something like:
 
-```json
+```json lines
 {
     "id": "4861c0c0-d46e-4ca2-b765-c66b45a41464",
     "type": "FILE",
@@ -65,7 +92,7 @@ The JSON representation of this asset would look like:
         },
         "bytes": {
             "type_url": "type.googleapis.com/google.protobuf.BytesValue",
-            "value": "Cq3zEYlQTkcNChoKAAAADUlIRF... image bytes truncated ...",
+            "value": "Cq3zEYlQTkcNChoKAAAADUlIRF", // Value truncated
         },
         "content-type": {
             "type_url": "type.googleapis.com/google.protobuf.StringValue",

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ val asset1 = asset {
 
 The JSON representation of this asset would look something like:
 
-```json lines
+```jsonc
 {
     "id": "4861c0c0-d46e-4ca2-b765-c66b45a41464",
     "type": "FILE",

--- a/src/test/kotlin/tech/figure/asset/v1beta1/AssetTest.kt
+++ b/src/test/kotlin/tech/figure/asset/v1beta1/AssetTest.kt
@@ -1,6 +1,10 @@
 package tech.figure.asset.v1beta1
 
-import com.google.protobuf.*
+import com.google.protobuf.ByteString
+import com.google.protobuf.BytesValue
+import com.google.protobuf.Int64Value
+import com.google.protobuf.Message
+import com.google.protobuf.StringValue
 import com.google.protobuf.Any
 import org.junit.jupiter.api.Test
 import tech.figure.proto.util.FileNFT


### PR DESCRIPTION
## Context
The README has some outdated information on the artifact group and the Protobuf Kotlin DSL syntax, so polishing the whole thing while I'm at it
## Changes
- Update README wording
- Add aesthetically pleasing badges to README
- Update outdated information in README
- Add links to relevant documentation and repositories
- Make imports used in Kotlin utility file absolute for easier understanding