### PR TITLE
Add signature field to DocumentMetadata; add a bit of documentation

### DIFF
--- a/docs/util.md
+++ b/docs/util.md
@@ -400,6 +400,7 @@ actual contents of the file are stored elsewhere (described by the `uri`).
 | content_type | [string](#string) |  | Where possible, use MIME type, such as `application/pdf` or `application/xml` |
 | document_type | [string](#string) |  | Examples: HELOC_AGREEMENT, CREDIT_DISCLOSURE, PROOF_OF_RECORDED_DEED, TRANSFER_OF_SERVICING_RIGHTS, etc. |
 | checksum | [Checksum](util.md#tech.figure.util.v1beta1.Checksum) |  | Hash or checksum of document bytes |
+| signature | [ElectronicSignature](util.md#tech.figure.util.v1beta1.ElectronicSignature) |  | A representation of an electronic signature |
 
 
 
@@ -423,6 +424,7 @@ actual contents of the file are stored elsewhere (described by the `uri`).
 | signing_timestamp | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  |  |
 | name | [Name](util.md#tech.figure.util.v1beta1.Name) |  |  |
 | witnesses | [Witness](util.md#tech.figure.util.v1beta1.Witness) | repeated |  |
+| signature_location | [PageLocation](util.md#tech.figure.util.v1beta1.PageLocation) |  | The location of the signature on a page |
 
 
 
@@ -495,7 +497,25 @@ Detail of the notary (person) who witnessed the signing and their commission inf
 | name | [Name](util.md#tech.figure.util.v1beta1.Name) |  |  |
 | commission_id | [string](#string) |  |  |
 | commission_expiration | [google.protobuf.Timestamp](#google.protobuf.Timestamp) |  |  |
-| is_resident | [bool](#bool) |  |  |
+| is_resident | [bool](#bool) |  | True if the notary is a resident of the state they are notarizing in |
+
+
+
+
+
+<a name="tech.figure.util.v1beta1.PageLocation"></a>
+
+### PageLocation
+A representation of a specific location on a page in a document, such as the location of a signature.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| page_index | [int32](#int32) |  | The index of the location's page in a multi-page document, if applicable |
+| x | [int32](#int32) |  | The x-coordinate of the location in the plane of the page |
+| y | [int32](#int32) |  | The y-coordinate of the location in the plane of the page |
+| width | [int32](#int32) |  | The width of the page |
+| height | [int32](#int32) |  | The height of the page |
 
 
 
@@ -511,7 +531,7 @@ Data or document digitally-signed by the source that created the data/document.
 | ----- | ---- | ----- | ----------- |
 | meta | [DocumentMetadata](util.md#tech.figure.util.v1beta1.DocumentMetadata) |  | Information about the data/document |
 | signature | [DigitalSignature](util.md#tech.figure.util.v1beta1.DigitalSignature) |  | Signature of vendor on this data/document |
-| data | [google.protobuf.BytesValue](#google.protobuf.BytesValue) |  | Byte array of data/docum``ent contents |
+| data | [google.protobuf.BytesValue](#google.protobuf.BytesValue) |  | Byte array of data/document contents |
 
 
 

--- a/src/main/proto/tech/figure/util/v1beta1/document.proto
+++ b/src/main/proto/tech/figure/util/v1beta1/document.proto
@@ -17,7 +17,7 @@ Data or document digitally-signed by the source that created the data/document.
 message SignedData {
   DocumentMetadata           meta      = 1 [(validate.rules).message.required = true];  // Information about the data/document
   DigitalSignature           signature = 22 [(validate.rules).message.required = true]; // Signature of vendor on this data/document
-  google.protobuf.BytesValue data      = 2 [(validate.rules).message.required = true];  // Byte array of data/docum``ent contents
+  google.protobuf.BytesValue data      = 2 [(validate.rules).message.required = true];  // Byte array of data/document contents
 }
 
 /*
@@ -31,6 +31,12 @@ message DocumentMetadata {
   string                content_type  = 4 [(validate.rules).string.min_len = 1];      // Where possible, use MIME type, such as `application/pdf` or `application/xml`
   string                document_type = 5 [(validate.rules).string.min_len = 1];      // Examples: HELOC_AGREEMENT, CREDIT_DISCLOSURE, PROOF_OF_RECORDED_DEED, TRANSFER_OF_SERVICING_RIGHTS, etc.
   Checksum              checksum      = 6;                                            // Hash or checksum of document bytes
+  /*
+  Optional data for a signature of the document.
+   */
+  oneof signature_type {
+    ElectronicSignature signature     = 10;                                           // A representation of an electronic signature
+  }
 }
 
 /*
@@ -79,6 +85,7 @@ message ESigData {
   google.protobuf.Timestamp     signing_timestamp        = 9;
   tech.figure.util.v1beta1.Name name                     = 10;
   repeated Witness              witnesses                = 11;
+  PageLocation                  signature_location       = 12; // The location of the signature on a page
 }
 
 /*
@@ -89,7 +96,7 @@ message Notary {
   tech.figure.util.v1beta1.Name name                  = 2;
   string                        commission_id         = 3;
   google.protobuf.Timestamp     commission_expiration = 4;
-  bool                          is_resident           = 5;
+  bool                          is_resident           = 5; // True if the notary is a resident of the state they are notarizing in
 }
 
 /*
@@ -98,4 +105,15 @@ A non-notary witness to the document signing
 message Witness {
   tech.figure.util.v1beta1.UUID person_id = 1 [(validate.rules).message.required = true];
   tech.figure.util.v1beta1.Name name      = 2;
+}
+
+/*
+A representation of a specific location on a page in a document, such as the location of a signature.
+ */
+message PageLocation {
+  int32 page_index = 1; // The index of the location's page in a multi-page document, if applicable
+  int32 x          = 2; // The x-coordinate of the location in the plane of the page
+  int32 y          = 3; // The y-coordinate of the location in the plane of the page
+  int32 width      = 4; // The width of the page
+  int32 height     = 5; // The height of the page
 }


### PR DESCRIPTION
## Context
Adding a signature field to `DocumentMetadata` to allow storing additional metadata for signed documents.
## Changes
### Minor
- Add a `oneof` signature field to `DocumentMetadata`, currently just of the already defined `ElectronicSignature`
- Define a new message `PageLocation` for the location of a signature on a page and add it to `ESigData`, part of `ElectronicSignature`
### Patch
- Add a few documentation comments and fix a typo in one existing comment
## Notes
- The `oneof` signature field should be completely optional for documents which do not or will not have signatures per [protobuf documentation](https://protobuf.dev/programming-guides/proto3/#oneof:~:text=fields%20and%20where-,at%20most%20one,-field%20will%20be).