### PR TITLE
Update Kotlin from 1.8.10 to 1.8.21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ buildscript {
 
 @Suppress("DSL_SCOPE_VIOLATION") /** https://github.com/gradle/gradle/issues/22797 */
 plugins {
-    kotlin("jvm") version "1.8.10"
+    kotlin("jvm") version "1.8.21"
     alias(libs.plugins.protobuf.gradle)
     alias(libs.plugins.protocGen.krotoPlus)
     `java-library`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 ## Kotlin
-kotlin = "1.8.10"
+kotlin = "1.8.21"
 ## Protocol Buffers
 krotoPlus = "0.6.1"
 protobuf = "3.21.12"


### PR DESCRIPTION
Updating Kotlin version from 1.8.10 to the latest patch, 1.8.21