### PR TITLE
Update Java from Temurin v11 to Zulu v17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,11 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
-          distribution: 'temurin'
+          java-version: 17.0.7
+          distribution: 'zulu'
 
       - name: Build with Gradle
         run: ./gradlew clean build --refresh-dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,11 +42,11 @@ jobs:
           echo "VERSION=$VERSION"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
-          distribution: 'temurin'
+          java-version: 17.0.7
+          distribution: 'zulu'
 
       - name: Build with Gradle
         run: ./gradlew clean build --refresh-dependencies -Pversion=$VERSION

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,8 +27,8 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
     withSourcesJar()
     withJavadocJar() /** Needed to pass Nexus validation rules */
 }
@@ -48,7 +48,7 @@ tasks.withType<KotlinCompile>().all {
         freeCompilerArgs += listOf(
             "-Xjsr305=strict",
         )
-        jvmTarget = "11"
+        jvmTarget = "17"
         apiVersion = "1.8"
         languageVersion = "1.8"
         /** Necessary to allow deprecation warnings from the Java & Kotlin generated for deprecated protobuf fields */

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=1024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
## Context
Updating Java to the next major version v17 to keep up with common consumers of this library
## Changes
- Update Java from Temurin v11 to Zulu v17
## To-Do
- Explore publishing separate Java 11 and Java 17 JARs